### PR TITLE
Import files to halt ``axsh/openvdc-images`` repository.

### DIFF
--- a/schema/v1.json
+++ b/schema/v1.json
@@ -1,0 +1,55 @@
+{
+  "id": "https://raw.githubusercontent.com/axsh/openvdc/master/schema/v1.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "OpenVDC Resource Template Description.",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "images": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "hypervisor": {
+            "type": "string",
+            "enum": [
+              "null",
+              "lxc"
+            ]
+          },
+          "download_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "checksum_type": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "minimum_vcpu": {
+            "type": "integer",
+            "default": 1
+          },
+          "minimum_memory_gb": {
+            "type": "integer",
+            "default": 1
+          }
+        },
+        "required": [
+          "hypervisor",
+          "download_url"
+        ]
+      }
+    }
+  },
+  "required": [
+    "title",
+    "images"
+  ]
+}

--- a/templates/centos-7.json
+++ b/templates/centos-7.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/axsh/openvdc/master/schema/v1.json#",
+  "title": "CentOS7",
+  "images": [
+    {
+      "hypervisor": "lxc",
+      "download_url": "https://images.linuxcontainers.org/1.0/images/d767cfe9a0df0b2213e28b39b61e8f79cb9b1e745eeed98c22bc5236f277309a/export"
+    }
+  ]
+}


### PR DESCRIPTION
As the data structure is not fixed yet, the separating repository was not right strategy at this stage.