### PR TITLE
Fix unit test.

### DIFF
--- a/hypervisor/types.go
+++ b/hypervisor/types.go
@@ -9,7 +9,6 @@ import (
 type HypervisorProvider interface {
 	Name() string
 	CreateDriver() (HypervisorDriver, error)
-	SetName(string)
 }
 
 type HypervisorDriver interface {
@@ -26,7 +25,7 @@ var (
 
 func RegisterProvider(name string, p HypervisorProvider) error {
 	if _, exists := hypervisorProviders[name]; exists {
-		return fmt.Errorf("Duplicated hypervisor provider registration: %s\n", name)
+		return fmt.Errorf("Duplicated hypervisor provider registration: %s", name)
 	}
 	hypervisorProviders[name] = p
 	log.Infof("Registered hypervisor provider: %s\n", name)

--- a/hypervisor/types.go
+++ b/hypervisor/types.go
@@ -9,6 +9,7 @@ import (
 type HypervisorProvider interface {
 	Name() string
 	CreateDriver() (HypervisorDriver, error)
+	SetName(string)
 }
 
 type HypervisorDriver interface {

--- a/hypervisor/types_test.go
+++ b/hypervisor/types_test.go
@@ -12,6 +12,8 @@ func (p *testProvider) CreateDriver() (HypervisorDriver, error) {
 	return &testDriver{}, nil
 }
 
+func (p *testProvider) SetName(string) {}
+
 type testDriver struct{}
 
 func (d *testDriver) StartInstance() error {

--- a/hypervisor/types_test.go
+++ b/hypervisor/types_test.go
@@ -22,6 +22,18 @@ func (d *testDriver) StopInstance() error {
 	return nil
 }
 
+func (d *testDriver) InstanceConsole() error {
+	return nil
+}
+
+func (d *testDriver) CreateInstance() error {
+	return nil
+}
+
+func (d *testDriver) DestroyInstance() error {
+	return nil
+}
+
 func TestProviderRegistry(t *testing.T) {
 	{
 		RegisterProvider("test", &testProvider{})


### PR DESCRIPTION
```
cd hypervisor
go test -v
```

got

```
# github.com/axsh/openvdc/hypervisor
./types_test.go:12: cannot use testDriver literal (type *testDriver) as type HypervisorDriver in return argument:
	*testDriver does not implement HypervisorDriver (missing CreateInstance method)
./types_test.go:27: cannot use testProvider literal (type *testProvider) as type HypervisorProvider in argument to RegisterProvider:
	*testProvider does not implement HypervisorProvider (missing SetName method)
FAIL	github.com/axsh/openvdc/hypervisor [build failed]
```