### PR TITLE
Fix unit test

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -2,13 +2,15 @@ package api
 
 import (
 	"net"
+	"os"
 	"testing"
 	"time"
 )
 
 func TestNewAPIServer(t *testing.T) {
 	c := make(APIOffer)
-	s := NewAPIServer(c)
+	// TODO: Set mock SchedulerDriver
+	s := NewAPIServer(c, os.Getenv("ZK"), nil)
 	if s == nil {
 		t.Error("NewAPIServer() returned nil")
 	}
@@ -20,7 +22,8 @@ func TestAPIServerRun(t *testing.T) {
 		t.Error(err)
 	}
 	c := make(APIOffer)
-	s := NewAPIServer(c)
+	// TODO: Set mock SchedulerDriver
+	s := NewAPIServer(c, os.Getenv("ZK"), nil)
 	go func() {
 		time.Sleep(2 * time.Second)
 		s.Stop()

--- a/hypervisor/types.go
+++ b/hypervisor/types.go
@@ -9,7 +9,6 @@ import (
 type HypervisorProvider interface {
 	Name() string
 	CreateDriver() (HypervisorDriver, error)
-	SetName(string)
 }
 
 type HypervisorDriver interface {
@@ -26,7 +25,7 @@ var (
 
 func RegisterProvider(name string, p HypervisorProvider) error {
 	if _, exists := hypervisorProviders[name]; exists {
-		return fmt.Errorf("Duplicated hypervisor provider registration: %s\n", name)
+		return fmt.Errorf("Duplicated hypervisor provider registration: %s", name)
 	}
 	hypervisorProviders[name] = p
 	log.Infof("Registered hypervisor provider: %s\n", name)

--- a/hypervisor/types.go
+++ b/hypervisor/types.go
@@ -9,6 +9,7 @@ import (
 type HypervisorProvider interface {
 	Name() string
 	CreateDriver() (HypervisorDriver, error)
+	SetName(string)
 }
 
 type HypervisorDriver interface {

--- a/hypervisor/types_test.go
+++ b/hypervisor/types_test.go
@@ -12,6 +12,8 @@ func (p *testProvider) CreateDriver() (HypervisorDriver, error) {
 	return &testDriver{}, nil
 }
 
+func (p *testProvider) SetName(string) {}
+
 type testDriver struct{}
 
 func (d *testDriver) StartInstance() error {

--- a/hypervisor/types_test.go
+++ b/hypervisor/types_test.go
@@ -22,6 +22,18 @@ func (d *testDriver) StopInstance() error {
 	return nil
 }
 
+func (d *testDriver) InstanceConsole() error {
+	return nil
+}
+
+func (d *testDriver) CreateInstance() error {
+	return nil
+}
+
+func (d *testDriver) DestroyInstance() error {
+	return nil
+}
+
 func TestProviderRegistry(t *testing.T) {
 	{
 		RegisterProvider("test", &testProvider{})


### PR DESCRIPTION
```
cd api
go test -v
```

got

```
# github.com/axsh/openvdc/api
./server_test.go:11: not enough arguments in call to NewAPIServer
./server_test.go:23: not enough arguments in call to NewAPIServer
FAIL	github.com/axsh/openvdc/api [build failed]
```