### PR TITLE
Stop to embed ExecutorPath as this disturbs the RPM packaging

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,12 +4,10 @@ $SHA=$(git rev-parse --verify HEAD)
 $BUILDDATE=Get-Date -Format "yyyy/MM/dd HH:mm:ss zzz"
 $GOVERSION=$(go version)
 $LDFLAGS="-X 'main.version=${VERSION}' -X 'main.sha=${SHA}' -X 'main.builddate=${BUILDDATE}' -X 'main.goversion=${GOVERSION}'"
-# During development, assume that the executor binary locates in the build directory.
-$EXECUTOR_PATH=Join-Path $(Get-Location) "openvdc-executor.exe"
 
 Invoke-Expression "$(Join-Path ${env:GOPATH}\bin govendor.exe -Resolve) sync"
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS" -ldflags "-X 'github.com/axsh/openvdc/scheduler.ExecutorPath=${EXECUTOR_PATH}'" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 Write-Host "Done"

--- a/build.sh
+++ b/build.sh
@@ -7,12 +7,10 @@ SHA=$(git rev-parse --verify HEAD)
 BUILDDATE=$(date '+%Y/%m/%d %H:%M:%S %Z')
 GOVERSION=$(go version)
 LDFLAGS="-X 'main.version=${VERSION}' -X 'main.sha=${SHA}' -X 'main.builddate=${BUILDDATE}' -X 'main.goversion=${GOVERSION}'"
-# During development, assume that the executor binary locates in the build directory.
-EXECUTOR_PATH=$(pwd)/openvdc-executor
 
 $GOPATH/bin/govendor sync
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS" -ldflags "-X 'github.com/axsh/openvdc/scheduler.ExecutorPath=${EXECUTOR_PATH}'" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 echo "Done"

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"fmt"
 	"net"
-	"os"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -24,9 +23,7 @@ const (
 	MEM_PER_TASK      = 64
 )
 
-// ExecutorPath is the path to the openvdc-executor binary.
-// Embed from -ldflags
-var ExecutorPath string
+const ExecutorPath = "openvdc-executor"
 
 var (
 	taskCount = 10
@@ -43,10 +40,6 @@ type VDCScheduler struct {
 }
 
 func newVDCScheduler(ch api.APIOffer, listenAddr string) *VDCScheduler {
-	// Assert ExecutorPath
-	if _, err := os.Stat(ExecutorPath); err != nil {
-		log.WithError(err).WithField("ExecutorPath", ExecutorPath).Fatal("Could not find openvdc-executor binary.")
-	}
 	exec := &mesos.ExecutorInfo{
 		ExecutorId: util.NewExecutorID("vdc-hypervisor-null"),
 		Name:       proto.String("VDC Executor"),


### PR DESCRIPTION
For developers, mesos-slave needs $PATH to be set to where you generate the openvdc-executor binary.  i.e.``$GOPATH/src/github.com/axsh/openvdc``.

```
% mesos-slave --executor_environment_variables="{\"PATH\":\"/Users/unakatsuo/go/src/github.com/axsh/openvdc:${PATH}\"}"
```