### PR TITLE
Unit tests under model/* fail for non-initialized Zookeeper 

### DIFF
--- a/model/instances_test.go
+++ b/model/instances_test.go
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/axsh/openvdc/model/backend"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +16,10 @@ func withConnect(t *testing.T, c func(context.Context)) error {
 		t.Fatal(err)
 	}
 	defer Close(ctx)
+	err = InstallSchemas(GetBackendCtx(ctx).(backend.ModelSchema))
+	if err != nil {
+		t.Fatal(err)
+	}
 	c(ctx)
 	return err
 }


### PR DESCRIPTION
Results in 

```
=== RUN   TestCreateInstance
2016/11/29 19:20:36 Recv loop terminated: err=EOF
2016/11/29 19:20:36 Send loop terminated: err=<nil>
2016/11/29 19:20:36 Connected to 127.0.0.1:2181
2016/11/29 19:20:36 Authenticated: id=97022577151836161, timeout=4000
2016/11/29 19:20:36 Re-submitting `0` credentials after reconnect
--- FAIL: TestCreateInstance (0.04s)
	assertions.go:241: 
                        
	Error Trace:	instances_test.go:37
		
			instances_test.go:18
		
			instances_test.go:39
		
	Error:		Received unexpected error:
			zk: node does not exist
		
	assertions.go:241: 
                        
	Error Trace:	instances_test.go:38
		
			instances_test.go:18
		
			instances_test.go:39
		
	Error:		Expected value not to be nil.
		
=== RUN   TestFindInstance
2016/11/29 19:20:36 Recv loop terminated: err=EOF
2016/11/29 19:20:36 Send loop terminated: err=<nil>
2016/11/29 19:20:36 Connected to 127.0.0.1:2181
2016/11/29 19:20:36 Authenticated: id=97022577151836162, timeout=4000
2016/11/29 19:20:36 Re-submitting `0` credentials after reconnect
--- FAIL: TestFindInstance (0.06s)
	assertions.go:241: 
                        
	Error Trace:	instances_test.go:53
		
			instances_test.go:18
		
			instances_test.go:60
		
	Error:		Received unexpected error:
			zk: node does not exist
```