### PR TITLE
Place to define flags/switch variables for unit tests.

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -2,15 +2,16 @@ package api
 
 import (
 	"net"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/axsh/openvdc/internal/unittest"
 )
 
 func TestNewAPIServer(t *testing.T) {
 	c := make(APIOffer)
 	// TODO: Set mock SchedulerDriver
-	s := NewAPIServer(c, os.Getenv("ZK"), nil)
+	s := NewAPIServer(c, unittest.TestZkServer, nil)
 	if s == nil {
 		t.Error("NewAPIServer() returned nil")
 	}
@@ -23,7 +24,7 @@ func TestAPIServerRun(t *testing.T) {
 	}
 	c := make(APIOffer)
 	// TODO: Set mock SchedulerDriver
-	s := NewAPIServer(c, os.Getenv("ZK"), nil)
+	s := NewAPIServer(c, unittest.TestZkServer, nil)
 	go func() {
 		time.Sleep(2 * time.Second)
 		s.Stop()

--- a/internal/unittest/flags.go
+++ b/internal/unittest/flags.go
@@ -1,0 +1,15 @@
+package unittest
+
+import (
+	"os"
+)
+
+// Place global variables or flags only for unit test code.
+
+var TestZkServer = "127.0.0.1:2181"
+
+func init() {
+	if v, exists := os.LookupEnv("ZK"); exists {
+		TestZkServer = v
+	}
+}

--- a/model/backend/zk_test.go
+++ b/model/backend/zk_test.go
@@ -1,22 +1,12 @@
 package backend
 
 import (
-	"os"
 	"testing"
 
+	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 )
-
-var testZkServer string
-
-func init() {
-	if os.Getenv("ZK") != "" {
-		testZkServer = os.Getenv("ZK")
-	} else {
-		testZkServer = "127.0.0.1"
-	}
-}
 
 func withConnect(t *testing.T, c func(z *Zk)) (err error) {
 	z := NewZkBackend()
@@ -25,7 +15,7 @@ func withConnect(t *testing.T, c func(z *Zk)) (err error) {
 		err = z.Delete(z.basePath)
 		z.Close()
 	}()
-	err = z.Connect([]string{testZkServer})
+	err = z.Connect([]string{unittest.TestZkServer})
 	if err != err {
 		t.Fatal(err)
 	}

--- a/model/connection_test.go
+++ b/model/connection_test.go
@@ -1,26 +1,16 @@
 package model
 
 import (
-	"os"
 	"testing"
 
-	"golang.org/x/net/context"
+	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
-
-var testZkServer string
-
-func init() {
-	if os.Getenv("ZK") != "" {
-                testZkServer = os.Getenv("ZK")
-        } else {
-                testZkServer = "127.0.0.1"
-        }
-}
 
 func TestConnect(t *testing.T) {
 	assert := assert.New(t)
-	ctx, err := Connect(context.Background(), []string{testZkServer})
+	ctx, err := Connect(context.Background(), []string{unittest.TestZkServer})
 	assert.NoError(err)
 	assert.NotNil(ctx)
 	err = Close(ctx)

--- a/model/instances_test.go
+++ b/model/instances_test.go
@@ -5,13 +5,14 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/axsh/openvdc/model/backend"
 	"github.com/stretchr/testify/assert"
 )
 
 func withConnect(t *testing.T, c func(context.Context)) error {
-	
-	ctx, err := Connect(context.Background(), []string{testZkServer})
+
+	ctx, err := Connect(context.Background(), []string{unittest.TestZkServer})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
As example, defined "unittest.TestZkServer" variable to be available from *_test.go code in any namespaces. 