### PR TITLE
Fix unit test failure in registry/github_test.go

### DIFF
--- a/internal/unittest/flags.go
+++ b/internal/unittest/flags.go
@@ -1,15 +1,17 @@
 package unittest
 
-import (
-	"os"
-)
+import "os"
 
 // Place global variables or flags only for unit test code.
 
 var TestZkServer = "127.0.0.1:2181"
+var GithubDefaultRef = "master"
 
 func init() {
 	if v, exists := os.LookupEnv("ZK"); exists {
 		TestZkServer = v
+	}
+	if v, exists := os.LookupEnv("GITHUB_DEFAULT_REF"); exists {
+		GithubDefaultRef = v
 	}
 }

--- a/registry/github.go
+++ b/registry/github.go
@@ -23,9 +23,8 @@ const (
 	mimeTypeGitUploadPack = "application/x-git-upload-pack-advertisement"
 )
 
-// Until 76f26d79b1be670 gets merged to master.
 // Build time flag
-var GithubDefaultRef = "generalize-template"
+var GithubDefaultRef = "master"
 
 type GithubRegistry struct {
 	confDir                 string

--- a/registry/github_test.go
+++ b/registry/github_test.go
@@ -6,8 +6,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	GithubDefaultRef = unittest.GithubDefaultRef
+}
 
 func TestNewGithubRegistry(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
https://ci.openvdc.org/job/citest/job/master/44/console

```
=== RUN   TestGithubFetch
--- FAIL: TestGithubFetch (1.12s)
	assertions.go:241: 
                        
	Error Trace:	github_test.go:27
		
	Error:		Received unexpected error:
			Counld not find the branch: generalize-template
		
	assertions.go:241: 
                        
	Error Trace:	github_test.go:29
		
	Error:		Received unexpected error:
			stat /tmp/reg-test034317804/registry/github.com-axsh-openvdc/generalize-template: no such file or directory
		
	assertions.go:241: 
                        
	Error Trace:	github_test.go:31
		
	Error:		Received unexpected error:
			stat /tmp/reg-test034317804/registry/github.com-axsh-openvdc/generalize-template.sha: no such file or directory
		
=== RUN   TestGitLsRemote
--- PASS: TestGitLsRemote (0.89s)
=== RUN   TestFind
--- FAIL: TestFind (0.92s)
	assertions.go:241: 
                        
	Error Trace:	github_test.go:51
		
	Error:		Received unexpected error:
			Counld not find the branch: generalize-template
		
	assertions.go:241: 
                        
	Error Trace:	github_test.go:54
		
	Error:		Received unexpected error:
			Resource template registry has not been cached yet
		
	assertions.go:241: 
                        
	Error Trace:	github_test.go:55
		
	Error:		Expected value not to be nil.
		
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x48d8ee]

goroutine 28 [running]:
panic(0x979520, 0xc82000e0e0)
	/usr/lib/golang/src/runtime/panic.go:481 +0x3e6
testing.tRunner.func1(0xc820076e10)
	/usr/lib/golang/src/testing/testing.go:467 +0x192
panic(0x979520, 0xc82000e0e0)
	/usr/lib/golang/src/runtime/panic.go:443 +0x4e9
github.com/axsh/openvdc/registry.TestFind(0xc820076e10)
	/var/tmp/go/src/github.com/axsh/openvdc/registry/github_test.go:56 +0x53e
testing.tRunner(0xc820076e10, 0xd3b5e8)
	/usr/lib/golang/src/testing/testing.go:473 +0x98
created by testing.RunTests
	/usr/lib/golang/src/testing/testing.go:582 +0x892
exit status 2
```