### PR TITLE
Jenkins input step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,29 +4,27 @@
 import groovy.transform.Field
 @Field final BUILD_OS_TARGETS=['el7']
 
-properties ([[$class: 'ParametersDefinitionProperty',
-  parameterDefinitions: [
-    [$class: 'ChoiceParameterDefinition',
-      choices: "all\n" + BUILD_OS_TARGETS.join("\n"), description: 'Target OS name', name: 'BUILD_OS'],
-    [$class: 'ChoiceParameterDefinition',
-      choices: "false\ntrue", description: 'Rebuild cache image', name: 'REBUILD'],
-    [$class: 'StringParameterDefinition',
-      defaultValue: '0', description: 'Leave container after build for debugging.', name: 'LEAVE_CONTAINER'],
-    [$class: 'StringParameterDefinition',
-      defaultValue: env.REPO_BASE_DIR, description: 'Path to create yum repository', name: 'REPO_BASE_DIR'],
-    [$class: 'StringParameterDefinition',
-      defaultValue: env.BUILD_CACHE_DIR, description: 'Directory for storing build cache archive', name: 'BUILD_CACHE_DIR']
-  ]
-]])
+@Field buildParams = [:]
+def ask_build_parameter = { ->
+  return input(message: "Build Parameters", id: "build_params",
+    parameters:[
+      [$class: 'ChoiceParameterDefinition',
+        choices: "all\n" + BUILD_OS_TARGETS.join("\n"), description: 'Target OS name', name: 'BUILD_OS'],
+      [$class: 'ChoiceParameterDefinition',
+        choices: "false\ntrue", description: 'Rebuild cache image', name: 'REBUILD'],
+      [$class: 'ChoiceParameterDefinition',
+        choices: "0\n1", description: 'Leave container after build for debugging.', name: 'LEAVE_CONTAINER'],
+    ])
+}
 
 def write_build_env(label) {
   def build_env="""# These parameters are read from bash and docker --env-file.
 # So do not use single or double quote for the value part.
-LEAVE_CONTAINER=${LEAVE_CONTAINER}
-REPO_BASE_DIR=${REPO_BASE_DIR}
-BUILD_CACHE_DIR=${BUILD_CACHE_DIR}
+LEAVE_CONTAINER=${buildParams.LEAVE_CONTAINER}
+REPO_BASE_DIR=${env.REPO_BASE_DIR}
+BUILD_CACHE_DIR=${env.BUILD_CACHE_DIR}
 BUILD_OS=${label}
-REBUILD=${REBUILD}
+REBUILD=${buildParams.REBUILD}
 RELEASE_SUFFIX=${RELEASE_SUFFIX}
 BRANCH=${env.BRANCH_NAME}
 """
@@ -66,7 +64,7 @@ def stage_integration(label) {
     checkout scm
     stage "Build Integration Environment"
     write_build_env(label)
-    
+
     sh "cd ci/multibox/ ; ./build.sh"
     stage "Run Tntegration Test"
     // This is where the integration test will be run
@@ -78,6 +76,7 @@ def stage_integration(label) {
 node() {
     stage "Checkout"
     checkout scm
+    buildParams = ask_build_parameter()
     // http://stackoverflow.com/questions/36507410/is-it-possible-to-capture-the-stdout-from-the-sh-dsl-command-in-the-pipeline
     // https://issues.jenkins-ci.org/browse/JENKINS-26133
     RELEASE_SUFFIX=sh(returnStdout: true, script: "./deployment/packagebuild/gen-dev-build-tag.sh").trim()
@@ -85,7 +84,7 @@ node() {
 
 
 build_nodes=BUILD_OS_TARGETS.clone()
-if( BUILD_OS != "all" ){
+if( buildParams.BUILD_OS != "all" ){
   build_nodes=[BUILD_OS]
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,15 @@ def ask_build_parameter = { ->
     ])
 }
 
+// Environment variables supplied by Jenkins system configuration:
+// env.REPO_BASE_DIR
+// env.BUILD_CACHE_DIR
 def write_build_env(label) {
   def build_env="""# These parameters are read from bash and docker --env-file.
 # So do not use single or double quote for the value part.
 LEAVE_CONTAINER=${buildParams.LEAVE_CONTAINER}
-REPO_BASE_DIR=${env.REPO_BASE_DIR}
-BUILD_CACHE_DIR=${env.BUILD_CACHE_DIR}
+REPO_BASE_DIR=${env.REPO_BASE_DIR ?: ''}
+BUILD_CACHE_DIR=${env.BUILD_CACHE_DIR ?: ''}
 BUILD_OS=${label}
 REBUILD=${buildParams.REBUILD}
 RELEASE_SUFFIX=${RELEASE_SUFFIX}


### PR DESCRIPTION
``properties`` step in Jenkinsfile causes Java exception at first time build. 

```
groovy.lang.MissingPropertyException: No such property: BUILD_OS for class: groovy.lang.Binding
	at groovy.lang.Binding.getVariable(Binding.java:63)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:224)
	at org.kohsuke.groovy.sandbox.impl.Checker$4.call(Checker.java:241)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:238)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:28)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
	at WorkflowScript.run(WorkflowScript:88)
	at ___cps.transform___(Native Method)
```

They provides another way to inject build parameters from WebUI. It only waits for 10 sec to pop up the window.

https://support.cloudbees.com/hc/en-us/articles/204986450-Pipeline-How-to-manage-user-inputs

![image](https://cloud.githubusercontent.com/assets/95236/21312496/b03ba1d0-c62f-11e6-93cb-e36f4c33c85f.png)
