### PR TITLE
Show version

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,11 @@
+[CmdletBinding()]
+param(
+    [parameter(Mandatory=$False,Position=1)]
+    [string]$VERSION = "dev"
+)
 
 $ErrorActionPreference = "Stop"
-$VERSION="dev"
+
 $SHA=$(git rev-parse --verify HEAD)
 $BUILDDATE=Get-Date -Format "yyyy/MM/dd HH:mm:ss zzz"
 $GOVERSION=$(go version)

--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,8 @@ $VERSION="dev"
 $SHA=$(git rev-parse --verify HEAD)
 $BUILDDATE=Get-Date -Format "yyyy/MM/dd HH:mm:ss zzz"
 $GOVERSION=$(go version)
-$LDFLAGS="-X 'main.version=${VERSION}' -X 'main.sha=${SHA}' -X 'main.builddate=${BUILDDATE}' -X 'main.goversion=${GOVERSION}'"
+$BUILDSTAMP="github.com/axsh/openvdc"
+$LDFLAGS="-X '${BUILDSTAMP}.Version=${VERSION}' -X '${BUILDSTAMP}.Sha=${SHA}' -X '${BUILDSTAMP}.Builddate=${BUILDDATE}' -X '${BUILDSTAMP}.Goversion=${GOVERSION}'"
 
 Invoke-Expression "$(Join-Path ${env:GOPATH}\bin govendor.exe -Resolve) sync"
 $modtime=$(git log -n 1 --date=raw --pretty=format:%cd -- schema/).split(" ")[0]
@@ -31,7 +32,7 @@ if( $env:APPVEYOR_REPO_BRANCH ){
         }
     }
 }
-$LDFLAGS="${LDFLAGS} -X 'registry.GithubDefaultRef=${branch}'"
+$LDFLAGS="${LDFLAGS} -X '${BUILDSTAMP}.GithubDefaultRef=${branch}'"
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-scheduler

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-VERSION="dev"
+VERSION=${VERSION:-"dev"}
 SHA=$(git rev-parse --verify HEAD)
 BUILDDATE=$(date '+%Y/%m/%d %H:%M:%S %Z')
 GOVERSION=$(go version)

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,8 @@ VERSION="dev"
 SHA=$(git rev-parse --verify HEAD)
 BUILDDATE=$(date '+%Y/%m/%d %H:%M:%S %Z')
 GOVERSION=$(go version)
-LDFLAGS="-X 'main.version=${VERSION}' -X 'main.sha=${SHA}' -X 'main.builddate=${BUILDDATE}' -X 'main.goversion=${GOVERSION}'"
+BUILDSTAMP="github.com/axsh/openvdc"
+LDFLAGS="-X '${BUILDSTAMP}.Version=${VERSION}' -X '${BUILDSTAMP}.Sha=${SHA}' -X '${BUILDSTAMP}.Builddate=${BUILDDATE}' -X '${BUILDSTAMP}.Goversion=${GOVERSION}'"
 
 if [[ ! -x $GOPATH/bin/govendor ]]; then
   go get -u github.com/kardianos/govendor
@@ -24,11 +25,11 @@ SCHEMA_LAST_COMMIT=${SCHEMA_LAST_COMMIT:-$(git log -n 1 --pretty=format:%H -- sc
 if (git rev-list origin/master | grep "${SCHEMA_LAST_COMMIT}") > /dev/null; then
   # Found no changes for resource template/schema on HEAD.
   # so that set preference to the master branch.
-  LDFLAGS="${LDFLAGS} -X 'registry.GithubDefaultRef=master'"
+  LDFLAGS="${LDFLAGS} -X '${BUILDSTAMP}.GithubDefaultRef=master'"
 else
   # Found resource template/schema changes on this HEAD. Switch the default reference branch.
   # Check if $GIT_BRANCH has something once in case of running in Jenkins.
-  LDFLAGS="${LDFLAGS} -X 'registry.GithubDefaultRef=${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}'"
+  LDFLAGS="${LDFLAGS} -X '${BUILDSTAMP}.GithubDefaultRef=${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}'"
 fi
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-	"flag"
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/axsh/openvdc"
 	"github.com/axsh/openvdc/model"
 	"github.com/axsh/openvdc/model/backend"
 	"github.com/axsh/openvdc/scheduler"
@@ -65,6 +66,7 @@ func execute(cmd *cobra.Command, args []string) {
 
 func main() {
 	flag.CommandLine.Parse([]string{})
+	rootCmd.AddCommand(openvdc.VersionCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/cmd/openvdc/cmd/root.go
+++ b/cmd/openvdc/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/axsh/openvdc"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,7 @@ func Execute() {
 	RootCmd.AddCommand(showCmd)
 	RootCmd.AddCommand(TemplateCmd)
 	RootCmd.AddCommand(listCmd)
+	RootCmd.AddCommand(openvdc.VersionCmd)
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/cmd/openvdc/main.go
+++ b/cmd/openvdc/main.go
@@ -10,14 +10,6 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-// Build time constant variables from -ldflags
-var (
-	version   string
-	sha       string
-	builddate string
-	goversion string
-)
-
 func setupDefaultUserConfig(dir string) error {
 	stat, err := os.Stat(dir)
 	if os.IsExist(err) && !stat.IsDir() {

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -37,7 +37,7 @@ This is an empty metapackage that depends on all OpenVNet services and the vnctl
 %build
 cd "${GOPATH}/src/github.com/axsh/openvdc"
 (
-  ./build.sh
+  VERSION=%{version} ./build.sh
 )
 
 %install

--- a/registry/github.go
+++ b/registry/github.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/axsh/openvdc"
 )
 
 const (
@@ -22,9 +23,6 @@ const (
 	defaultPath           = "templates"
 	mimeTypeGitUploadPack = "application/x-git-upload-pack-advertisement"
 )
-
-// Build time flag
-var GithubDefaultRef = "resource-handler"
 
 type GithubRegistry struct {
 	confDir                 string
@@ -37,7 +35,7 @@ type GithubRegistry struct {
 func NewGithubRegistry(confDir string) *GithubRegistry {
 	return &GithubRegistry{
 		confDir:                 confDir,
-		Branch:                  GithubDefaultRef,
+		Branch:                  openvdc.GithubDefaultRef,
 		RepoSlug:                githubRepoSlug,
 		TreePath:                defaultPath,
 		ForceCheckToRemoteAfter: 1 * time.Hour,

--- a/registry/github_test.go
+++ b/registry/github_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/axsh/openvdc"
 	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/stretchr/testify/assert"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func init() {
-	GithubDefaultRef = unittest.GithubDefaultRef
+	openvdc.GithubDefaultRef = unittest.GithubDefaultRef
 }
 
 func TestNewGithubRegistry(t *testing.T) {

--- a/registry/remote_test.go
+++ b/registry/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/axsh/openvdc/internal/unittest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func TestRemoteRegistryFind(t *testing.T) {
 	assert := assert.New(t)
 	reg := NewRemoteRegistry()
 	rt, err := reg.Find(fmt.Sprintf("%s/%s/%s/templates/centos/7/lxc.json",
-		githubRawURI, githubRepoSlug, GithubDefaultRef))
+		githubRawURI, githubRepoSlug, unittest.GithubDefaultRef))
 	assert.NoError(err)
 	assert.NotNil(rt)
 	assert.Equal(rt.source, reg)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,31 @@
+package openvdc
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Build time constant variables from -ldflags
+var (
+	Version   string
+	Sha       string
+	Builddate string
+	Goversion string
+)
+var GithubDefaultRef = "master"
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version",
+	Long:  "Show version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s version %s (git: %s, build: %s, goversion: %s)\n",
+			cmd.Root().CommandPath(),
+			Version,
+			Sha[:8],
+			Builddate,
+			Goversion,
+		)
+	},
+}


### PR DESCRIPTION
Add "version" sub command to ``github.com/spf13/cobra`` based CLIs.

- ``build.sh`` accepts ``$VERSION`` environment variable. ``dev`` is the default value.
    - ``build.ps1 -VERSION "xxxx"`` does same. 

```
$ ./openvdc version
openvdc version dev (git: 522fe83e, build: 2017/01/05 22:08:08 JST, goversion: go version go1.7.4 darwin/amd64)
$ ./openvdc-scheduler version
openvdc-scheduler version dev (git: 522fe83e, build: 2017/01/05 22:08:08 JST, goversion: go version go1.7.4 darwin/amd64)
```