### PR TITLE
Fix build error: [Errno -1] repomd.xml does not match metalink for epel

### DIFF
--- a/ci/devbox/devbox-centos7.json
+++ b/ci/devbox/devbox-centos7.json
@@ -74,7 +74,7 @@
       "execute_command": "chmod +x {{ .Path }}; echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "inline": [
         "cp /tmp/fastestmirror.conf /etc/yum/pluginconf.d/fastestmirror.conf",
-        "yum install -y epel-release",
+        "yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm",
         "yum install -y yum-utils rpm-build",
         "yum-builddep -y /tmp/openvdc.spec",
         "yum install -y bridge-utils lsof bind-utils iproute tree tmux screen",

--- a/deployment/docker/el7-unit-tests.Dockerfile
+++ b/deployment/docker/el7-unit-tests.Dockerfile
@@ -1,10 +1,11 @@
 FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
-RUN yum install -y epel-release
+# epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
 
-RUN yum install -y git go 
-ENV GOPATH=/var/tmp/go 
+RUN yum install -y git go
+ENV GOPATH=/var/tmp/go
 ENV PATH=$PATH:$GOPATH/bin
 RUN mkdir $GOPATH
 

--- a/deployment/docker/el7.Dockerfile
+++ b/deployment/docker/el7.Dockerfile
@@ -1,7 +1,9 @@
 FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
-RUN yum install -y yum-utils go git epel-release createrepo
+# epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+RUN yum install -y yum-utils go git createrepo
 
 
 ENV GOPATH=/var/tmp/go PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
As Fedora EPEL and CentOS are different project so that EPEL mirror sites clean old releases based on its release schedule. 

``yum install -y epel-release`` installs from CentOS/extra repository and then the package version is fixed at the CentOS minor release. The latest EPEL release is 7.8 but CentOS 7.3/extra repository still has 7.6.

So some build script/configuration were changed to install the version specified epel-release.rpm from ``fedoraproject.org``.

Build log for the issue encountered:

```
epel                                                     | 4.3 kB     00:00     
http://ftp.jaist.ac.jp/pub/Linux/Fedora/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel
Trying other mirror.

epel                                                     | 4.3 kB     00:00     
http://ftp.riken.jp/Linux/fedora/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel
Trying other mirror.

epel                                                     | 4.3 kB     00:00     
https://epel.mirror.angkasa.id/pub/epel/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml does not match metalink for epel
```