### PR TITLE
CI: Merge before build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,12 +42,17 @@ BRANCH=${env.BRANCH_NAME}
   writeFile(file: "build.env", text: build_env)
 }
 
+def checkout_and_merge {
+    checkout scm
+    sh "git merge origin/master"
+}
+
 @Field RELEASE_SUFFIX=null
 
 def stage_unit_test(label) {
   node(label) {
     stage "Units Tests ${label}"
-    checkout scm
+    checkout_and_merge
     write_build_env(label)
     sh "./deployment/docker/unit-tests.sh ./build.env"
   }
@@ -56,7 +61,7 @@ def stage_unit_test(label) {
 def stage_rpmbuild(label) {
   node(label) {
     stage "RPM Build ${label}"
-    checkout scm
+    checkout_and_merge
     write_build_env(label)
     sh "./deployment/docker/rpmbuild.sh ./build.env"
   }
@@ -64,7 +69,7 @@ def stage_rpmbuild(label) {
 
 def stage_integration(label) {
   node("multibox") {
-    checkout scm
+    checkout_and_merge
     stage "Build Integration Environment"
     write_build_env(label)
 
@@ -85,7 +90,7 @@ node() {
     }catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException err) {
       // Only ignore errors for timeout.
     }
-    checkout scm
+    checkout_and_merge
     // http://stackoverflow.com/questions/36507410/is-it-possible-to-capture-the-stdout-from-the-sh-dsl-command-in-the-pipeline
     // https://issues.jenkins-ci.org/browse/JENKINS-26133
     RELEASE_SUFFIX=sh(returnStdout: true, script: "./deployment/packagebuild/gen-dev-build-tag.sh").trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ def checkout_and_merge() {
 def stage_unit_test(label) {
   node(label) {
     stage "Units Tests ${label}"
-    checkout_and_merge
+    checkout_and_merge()
     write_build_env(label)
     sh "./deployment/docker/unit-tests.sh ./build.env"
   }
@@ -61,7 +61,7 @@ def stage_unit_test(label) {
 def stage_rpmbuild(label) {
   node(label) {
     stage "RPM Build ${label}"
-    checkout_and_merge
+    checkout_and_merge()
     write_build_env(label)
     sh "./deployment/docker/rpmbuild.sh ./build.env"
   }
@@ -69,7 +69,7 @@ def stage_rpmbuild(label) {
 
 def stage_integration(label) {
   node("multibox") {
-    checkout_and_merge
+    checkout_and_merge()
     stage "Build Integration Environment"
     write_build_env(label)
 
@@ -90,7 +90,7 @@ node() {
     }catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException err) {
       // Only ignore errors for timeout.
     }
-    checkout_and_merge
+    checkout_and_merge()
     // http://stackoverflow.com/questions/36507410/is-it-possible-to-capture-the-stdout-from-the-sh-dsl-command-in-the-pipeline
     // https://issues.jenkins-ci.org/browse/JENKINS-26133
     RELEASE_SUFFIX=sh(returnStdout: true, script: "./deployment/packagebuild/gen-dev-build-tag.sh").trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ BRANCH=${env.BRANCH_NAME}
   writeFile(file: "build.env", text: build_env)
 }
 
-def checkout_and_merge {
+def checkout_and_merge() {
     checkout scm
     sh "git merge origin/master"
 }


### PR DESCRIPTION
I set it up so the CI merges in master locally before building. After all we are testing to make sure that the code on master doesn't break after merge. Therefore the tests have to be run *after* a merge has taken place.

Then once it's green, we an do the merge on github too by clicking on the merge button in the PR. ^_^