### PR TITLE
Just a quick fix

### DIFF
--- a/registry/github.go
+++ b/registry/github.go
@@ -24,7 +24,7 @@ const (
 )
 
 // Build time flag
-var GithubDefaultRef = "resource-handler"
+var GithubDefaultRef = "master"
 
 type GithubRegistry struct {
 	confDir                 string


### PR DESCRIPTION
A few branches, including the master, are still referring to the branch "resource-handler" which doesn't exist anymore. So here's a quick solution to that.