### PR TITLE
Load user config from $HOME/.openvdc

### DIFF
--- a/cmd/openvdc/cmd/log.go
+++ b/cmd/openvdc/cmd/log.go
@@ -7,8 +7,8 @@ import (
 
 	mlog "github.com/ContainX/go-mesoslog/mesoslog"
 	log "github.com/Sirupsen/logrus"
-	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var tail bool
@@ -31,7 +31,7 @@ var logCmd = &cobra.Command{
 
 		instanceID := "VDC_" + args[0]
 
-		split := strings.Split(util.MesosMasterAddr, ":")
+		split := strings.Split(viper.GetString("mesos.master"), ":")
 		mesosMasterAddr := split[0]
 		mesosMasterPort, err := strconv.Atoi(split[1])
 

--- a/cmd/openvdc/cmd/root.go
+++ b/cmd/openvdc/cmd/root.go
@@ -56,9 +56,9 @@ func init() {
 
 	pfs := RootCmd.PersistentFlags()
 	pfs.String("config", filepath.Join(util.UserConfDir, "config.toml"), "Load config file from the path")
-	pfs.StringVar(&util.MesosMasterAddr, "master", viper.GetString("mesos.master"), "Mesos Master node address")
+	pfs.String("master", viper.GetString("mesos.master"), "Mesos Master node address")
 	viper.BindPFlag("mesos.master", pfs.Lookup("master"))
-	pfs.StringVar(&util.ServerAddr, "server", viper.GetString("api.address"), "gRPC API server address")
+	pfs.String("server", viper.GetString("api.address"), "gRPC API server address")
 	pfs.SetAnnotation("server", cobra.BashCompSubdirsInDir, []string{})
 	viper.BindPFlag("api.address", pfs.Lookup("server"))
 	// Cobra also supports local flags, which will only run

--- a/cmd/openvdc/cmd/root.go
+++ b/cmd/openvdc/cmd/root.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/axsh/openvdc"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var cfgFile string
@@ -44,15 +47,35 @@ func Execute() {
 }
 
 func init() {
+	cobra.OnInitialize(initConfig)
 	// Here you will define your flags and configuration settings.
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
+	viper.SetDefault("mesos.master", "127.0.0.1:5050")
+	viper.SetDefault("api.address", "127.0.0.1:5000")
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.openvdc.yaml)")
+	pfs := RootCmd.PersistentFlags()
+	pfs.String("config", filepath.Join(util.UserConfDir, "config.toml"), "Load config file from the path")
+	pfs.StringVar(&util.MesosMasterAddr, "master", viper.GetString("mesos.master"), "Mesos Master node address")
+	viper.BindPFlag("mesos.master", pfs.Lookup("master"))
+	pfs.StringVar(&util.ServerAddr, "server", viper.GetString("api.address"), "gRPC API server address")
+	pfs.SetAnnotation("server", cobra.BashCompSubdirsInDir, []string{})
+	viper.BindPFlag("api.address", pfs.Lookup("server"))
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	RootCmd.PersistentFlags().StringVarP(&util.MesosMasterAddr, "master", "", "127.0.0.1:5050", "Mesos Master node address")
-	RootCmd.PersistentFlags().StringVarP(&util.ServerAddr, "server", "s", "127.0.0.1:5000", "gRPC API server address")
-	RootCmd.PersistentFlags().SetAnnotation("server", cobra.BashCompSubdirsInDir, []string{})
+}
+
+func initConfig() {
+	f := RootCmd.PersistentFlags().Lookup("config")
+	if f.Changed {
+		viper.SetConfigFile(f.Value.String())
+	}
+	viper.SetConfigName("config")
+	viper.AddConfigPath(filepath.Join(util.UserConfDir))
+	viper.AutomaticEnv()
+	err := viper.ReadInConfig()
+	if err != nil {
+		log.Fatalf("Failed to load config %s: %v", viper.ConfigFileUsed(), err)
+	}
 }

--- a/cmd/openvdc/cmd/root.go
+++ b/cmd/openvdc/cmd/root.go
@@ -52,15 +52,15 @@ func init() {
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
 	viper.SetDefault("mesos.master", "127.0.0.1:5050")
-	viper.SetDefault("api.address", "127.0.0.1:5000")
+	viper.SetDefault("api.endpoint", "127.0.0.1:5000")
 
 	pfs := RootCmd.PersistentFlags()
 	pfs.String("config", filepath.Join(util.UserConfDir, "config.toml"), "Load config file from the path")
 	pfs.String("master", viper.GetString("mesos.master"), "Mesos Master node address")
 	viper.BindPFlag("mesos.master", pfs.Lookup("master"))
-	pfs.String("server", viper.GetString("api.address"), "gRPC API server address")
+	pfs.String("server", viper.GetString("api.endpoint"), "gRPC API server address")
 	pfs.SetAnnotation("server", cobra.BashCompSubdirsInDir, []string{})
-	viper.BindPFlag("api.address", pfs.Lookup("server"))
+	viper.BindPFlag("api.endpoint", pfs.Lookup("server"))
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/cmd/openvdc/internal/util/util.go
+++ b/cmd/openvdc/internal/util/util.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func RemoteCall(c func(*grpc.ClientConn) error) error {
-	serverAddr := viper.GetString("api.address")
+	serverAddr := viper.GetString("api.endpoint")
 	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
 	if err != nil {
 		log.WithField("endpoint", serverAddr).Fatalf("Cannot connect to OpenVDC gRPC endpoint: %v", err)

--- a/cmd/openvdc/internal/util/util.go
+++ b/cmd/openvdc/internal/util/util.go
@@ -8,10 +8,12 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -24,6 +26,18 @@ import (
 var MesosMasterAddr string
 var ServerAddr string
 var UserConfDir string
+
+func init() {
+	// UserConfDir variable is referenced from init() in cmd/root.go
+	// so that it has to be initialized eagerly.
+	//http://stackoverflow.com/questions/7922270/obtain-users-home-directory
+	path, err := homedir.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to locate user home path: %v", err)
+		os.Exit(1)
+	}
+	UserConfDir = filepath.Join(path, ".openvdc")
+}
 
 func RemoteCall(c func(*grpc.ClientConn) error) error {
 	conn, err := grpc.Dial(ServerAddr, grpc.WithInsecure())

--- a/cmd/openvdc/internal/util/util.go
+++ b/cmd/openvdc/internal/util/util.go
@@ -16,6 +16,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
 	"github.com/axsh/openvdc/handlers"
 	"github.com/axsh/openvdc/model"
@@ -23,8 +24,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-var MesosMasterAddr string
-var ServerAddr string
 var UserConfDir string
 
 func init() {
@@ -40,9 +39,10 @@ func init() {
 }
 
 func RemoteCall(c func(*grpc.ClientConn) error) error {
-	conn, err := grpc.Dial(ServerAddr, grpc.WithInsecure())
+	serverAddr := viper.GetString("api.address")
+	conn, err := grpc.Dial(serverAddr, grpc.WithInsecure())
 	if err != nil {
-		log.WithField("endpoint", ServerAddr).Fatalf("Cannot connect to OpenVDC gRPC endpoint: %v", err)
+		log.WithField("endpoint", serverAddr).Fatalf("Cannot connect to OpenVDC gRPC endpoint: %v", err)
 	}
 	defer conn.Close()
 	return c(conn)

--- a/cmd/openvdc/main.go
+++ b/cmd/openvdc/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -9,33 +10,36 @@ import (
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
 )
 
+const defaultTomlConfig = `
+[api]
+# endpoint = 127.0.0.1:5000
+[mesos]
+# address = 127.0.0.1:5050
+`
+
 func setupDefaultUserConfig(dir string) error {
 	stat, err := os.Stat(dir)
-	if os.IsExist(err) && !stat.IsDir() {
-		return fmt.Errorf("")
-	} else if os.IsNotExist(err) {
-		err = os.Mkdir(dir, 0755)
-		if err != nil {
-			return err
+	if err == nil {
+		if stat.IsDir() {
+			// nothing to do
+			return nil
+		} else {
+			return fmt.Errorf("%s is not directory", dir)
 		}
 	}
-	// Install default configuration file here.
-	confPath := filepath.Join(dir, "config")
-	_, err = os.Open(confPath)
-	if os.IsNotExist(err) {
-		f, err := os.Create(confPath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
+	err = os.Mkdir(dir, 0755)
+	if err != nil {
+		return err
 	}
-	return nil
+	confPath := filepath.Join(dir, "config.toml")
+	// Install default configuration file.
+	return ioutil.WriteFile(confPath, []byte(defaultTomlConfig), 0644)
 }
 
 func main() {
 	err := setupDefaultUserConfig(util.UserConfDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to setup %s\n", util.UserConfDir)
+		fmt.Fprintf(os.Stderr, "Failed to setup %s: %v\n", util.UserConfDir, err)
 		os.Exit(1)
 	}
 	cmd.Execute()

--- a/cmd/openvdc/main.go
+++ b/cmd/openvdc/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/axsh/openvdc/cmd/openvdc/cmd"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 func setupDefaultUserConfig(dir string) error {
@@ -34,14 +33,7 @@ func setupDefaultUserConfig(dir string) error {
 }
 
 func main() {
-	//http://stackoverflow.com/questions/7922270/obtain-users-home-directory
-	path, err := homedir.Dir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get $HOME")
-		os.Exit(1)
-	}
-	util.UserConfDir = filepath.Join(path, ".openvdc")
-	err = setupDefaultUserConfig(util.UserConfDir)
+	err := setupDefaultUserConfig(util.UserConfDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to setup %s\n", util.UserConfDir)
 		os.Exit(1)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -82,6 +82,60 @@
 			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
+			"checksumSHA1": "Ok3Csn6Voou7pQT6Dv2mkwpqFtw=",
+			"path": "github.com/hashicorp/hcl",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "XQmjDva9JCGGkIecOgwtBEMCJhU=",
+			"path": "github.com/hashicorp/hcl/hcl/ast",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "vF6LLywGDoAaccTcAGrcY7mYvZc=",
+			"path": "github.com/hashicorp/hcl/hcl/parser",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "z6wdP4mRw4GVjShkNHDaOWkbxS0=",
+			"path": "github.com/hashicorp/hcl/hcl/scanner",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "oS3SCN9Wd6D8/LG0Yx1fu84a7gI=",
+			"path": "github.com/hashicorp/hcl/hcl/strconv",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
+			"path": "github.com/hashicorp/hcl/hcl/token",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "138aCV5n8n7tkGYMsMVQQnnLq+0=",
+			"path": "github.com/hashicorp/hcl/json/parser",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
+			"path": "github.com/hashicorp/hcl/json/scanner",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
+			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
+			"path": "github.com/hashicorp/hcl/json/token",
+			"revision": "80e628d796135357b3d2e33a985c666b9f35eee1",
+			"revisionTime": "2016-12-15T22:58:39Z"
+		},
+		{
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"path": "github.com/inconshreveable/mousetrap",
 			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
@@ -94,10 +148,10 @@
 			"revisionTime": "2013-11-06T22:25:44Z"
 		},
 		{
-			"checksumSHA1": "S6PDDQMYaKwLDIP/NsRYb4FRAqQ=",
+			"checksumSHA1": "506eXGmFfB7mgzbMcsdT/UAXJgI=",
 			"path": "github.com/magiconair/properties",
-			"revision": "0723e352fa358f9322c938cc2dadda874e9151a9",
-			"revisionTime": "2016-09-08T09:36:58Z"
+			"revision": "9c47895dc1ce54302908ab8a43385d1f5df2c11c",
+			"revisionTime": "2016-11-28T00:34:34Z"
 		},
 		{
 			"checksumSHA1": "AwL6gGPNrpKip+E2J1RUtOQRqMc=",
@@ -202,10 +256,10 @@
 			"revisionTime": "2016-06-21T17:42:43Z"
 		},
 		{
-			"checksumSHA1": "UuXgD2dDojfS8AViUEe15gLIWZE=",
+			"checksumSHA1": "LAR/G/IY1GviHYkGAoi6kVXq1Jg=",
 			"path": "github.com/mitchellh/mapstructure",
-			"revision": "f3009df150dadf309fdee4a54ed65c124afad715",
-			"revisionTime": "2016-10-20T16:18:36Z"
+			"revision": "bfdb1a85537d60bc7e954e600c250219ea497417",
+			"revisionTime": "2016-12-11T22:23:15Z"
 		},
 		{
 			"checksumSHA1": "mhvIMH8oAtOiEyg37zWKmgb+6v4=",
@@ -220,10 +274,10 @@
 			"revisionTime": "2016-01-24T19:35:03Z"
 		},
 		{
-			"checksumSHA1": "CtI2rBQw2rxHNIU+a0rcAf29Sco=",
+			"checksumSHA1": "Ur3oHB8hzTudM8y0xHRoUXAf0IY=",
 			"path": "github.com/pelletier/go-toml",
-			"revision": "45932ad32dfdd20826f5671da37a5f3ce9f26a8d",
-			"revisionTime": "2016-09-20T07:07:15Z"
+			"revision": "439fbba1f887c286024370cb4f281ba815c4c7d7",
+			"revisionTime": "2016-12-29T18:51:04Z"
 		},
 		{
 			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
@@ -251,16 +305,16 @@
 			"revisionTime": "2016-10-28T23:23:40Z"
 		},
 		{
-			"checksumSHA1": "59wTbS4fE2282Q88NrBYImbFGbo=",
+			"checksumSHA1": "iGmLeUVcmiFgd4/iK2Tmx7WIoa4=",
 			"path": "github.com/spf13/afero",
-			"revision": "52e4a6cfac46163658bd4f123c49b6ee7dc75f78",
-			"revisionTime": "2016-09-19T21:01:14Z"
+			"revision": "90dd71edc4d0a8b3511dc12ea15d617d03be09e0",
+			"revisionTime": "2016-12-26T09:19:39Z"
 		},
 		{
 			"checksumSHA1": "u6B0SEgZ/TUEfIvF6w/HnFVQbII=",
 			"path": "github.com/spf13/afero/mem",
-			"revision": "52e4a6cfac46163658bd4f123c49b6ee7dc75f78",
-			"revisionTime": "2016-09-19T21:01:14Z"
+			"revision": "90dd71edc4d0a8b3511dc12ea15d617d03be09e0",
+			"revisionTime": "2016-12-26T09:19:39Z"
 		},
 		{
 			"checksumSHA1": "sLyAUiIT7V0DNVp6yBhW4Ms5BEs=",
@@ -269,10 +323,10 @@
 			"revisionTime": "2016-09-19T21:01:14Z"
 		},
 		{
-			"checksumSHA1": "M4qI7Ul0vf2uj3fF69DvRnwqfd0=",
+			"checksumSHA1": "WASQjQVYHiVtAOxvRbl6I23etGE=",
 			"path": "github.com/spf13/cast",
-			"revision": "2580bc98dc0e62908119e4737030cc2fdfc45e4c",
-			"revisionTime": "2016-09-26T08:42:49Z"
+			"revision": "56a7ecbeb18dde53c6db4bd96b541fd9741b8d44",
+			"revisionTime": "2016-12-24T17:25:03Z"
 		},
 		{
 			"checksumSHA1": "RQVbXPF9PMC9sTu8lr+uv8JtPPk=",
@@ -281,16 +335,22 @@
 			"revisionTime": "2016-12-14T15:19:52Z"
 		},
 		{
-			"checksumSHA1": "dkruahfhuLXXuyeCuRpsWlcRK+8=",
+			"checksumSHA1": "HWDERqbEvvfLwzP7Dvh2fvu+sng=",
 			"path": "github.com/spf13/jwalterweatherman",
-			"revision": "33c24e77fb80341fe7130ee7c594256ff08ccc46",
-			"revisionTime": "2016-03-01T12:00:06Z"
+			"revision": "bccdd23ae5e51bd2b081814db093646c7af3d34d",
+			"revisionTime": "2017-01-05T10:55:09Z"
 		},
 		{
 			"checksumSHA1": "AxfxmmBpbjQoaQKXbERcEw9pv+U=",
 			"path": "github.com/spf13/pflag",
 			"revision": "25f8b5b07aece3207895bf19f7ab517eb3b22a40",
 			"revisionTime": "2016-12-14T04:49:49Z"
+		},
+		{
+			"checksumSHA1": "Ru5RGygreAp5OW9B6kO5Zawjt08=",
+			"path": "github.com/spf13/viper",
+			"revision": "5ed0fc31f7f453625df314d8e66b9791e8d13003",
+			"revisionTime": "2016-12-13T09:38:49Z"
 		},
 		{
 			"checksumSHA1": "Q2V7Zs3diLmLfmfbiuLpSxETSuY=",
@@ -383,22 +443,22 @@
 			"revisionTime": "2016-10-26T17:59:44Z"
 		},
 		{
-			"checksumSHA1": "aVgPDgwY3/t4J/JOw9H3FVMHqh0=",
+			"checksumSHA1": "uTQtOqR0ePMMcvuvAIksiIZxhqU=",
 			"path": "golang.org/x/sys/unix",
-			"revision": "c200b10b5d5e122be351b67af224adc6128af5bf",
-			"revisionTime": "2016-10-22T18:22:21Z"
+			"revision": "d75a52659825e75fff6158388dddc6a5b04f9ba5",
+			"revisionTime": "2016-12-14T18:38:57Z"
 		},
 		{
 			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
 			"path": "golang.org/x/text/transform",
-			"revision": "a8b38433e35b65ba247bb267317037dee1b70cea",
-			"revisionTime": "2016-10-19T13:35:53Z"
+			"revision": "44f4f658a783b0cee41fe0a23b8fc91d9c120558",
+			"revisionTime": "2016-12-29T11:00:09Z"
 		},
 		{
 			"checksumSHA1": "Vircurgvsnt4k26havmxPM67PUA=",
 			"path": "golang.org/x/text/unicode/norm",
-			"revision": "a8b38433e35b65ba247bb267317037dee1b70cea",
-			"revisionTime": "2016-10-19T13:35:53Z"
+			"revision": "44f4f658a783b0cee41fe0a23b8fc91d9c120558",
+			"revisionTime": "2016-12-29T11:00:09Z"
 		},
 		{
 			"checksumSHA1": "xyB2Py2ViSKX8Td+oe2hxG6f0Ak=",


### PR DESCRIPTION
``openvdc`` CLI has several common flags, that spf13/cobra says PersistentFlags. They had to be passed to the CLI everytime in order to specify the server address to connect. They should be able to save as the user local configuration file.

``github.com/spf13/viper`` provides the feature to load configuration from multiple sources and to get merged value in loading priority.

Discussions:

1. ``spf13/viper`` supports multiple formats, json, yaml, toml and hcl. which is/are better to support? Or which format should be rejected.
    - My opinion is ``.toml`` and then ``.json`` or ``.yaml``. ``.hcl`` can be ignored.
2. Might be out of scope this PR, ``openvdc-scheduler`` should it use the same framework?


TODO:

- [x] non-default config file can be set with ``--config`` flag.
- [x] Binds ``--server`` and ``--master`` flags to viper namespace. 
- [x] Install default configuration file ``config.toml`` if not exist.
- [x] On windows, ``openvdc help`` shows correct user home location.