### PR TITLE
Fix print contents from CLI

### DIFF
--- a/cmd/openvdc/cmd/create.go
+++ b/cmd/openvdc/cmd/create.go
@@ -38,7 +38,7 @@ var createCmd = &cobra.Command{
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			fmt.Println(res)
+			fmt.Println(res.GetInstanceId())
 			return err
 		})
 	},

--- a/cmd/openvdc/cmd/destroy.go
+++ b/cmd/openvdc/cmd/destroy.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
 
@@ -30,12 +28,11 @@ var destroyCmd = &cobra.Command{
 		return util.RemoteCall(func(conn *grpc.ClientConn) error {
 			c := api.NewInstanceClient(conn)
 
-			res, err := c.Destroy(context.Background(), req)
+			_, err := c.Destroy(context.Background(), req)
 			if err != nil {
 				log.WithError(err).Fatal("Disconnected abnormally")
 				return err
 			}
-			fmt.Println(res)
 			return err
 		})
 	},

--- a/cmd/openvdc/cmd/register.go
+++ b/cmd/openvdc/cmd/register.go
@@ -58,7 +58,7 @@ var registerCmd = &cobra.Command{
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			fmt.Println(res)
+			fmt.Println(res.GetID())
 			return err
 		})
 	},

--- a/cmd/openvdc/cmd/run.go
+++ b/cmd/openvdc/cmd/run.go
@@ -45,7 +45,6 @@ var runCmd = &cobra.Command{
 				break
 			}
 		}
-		fmt.Println(left)
 		req := prepareRegisterAPICall(templateSlug, left)
 		return util.RemoteCall(func(conn *grpc.ClientConn) error {
 			c := api.NewInstanceClient(conn)
@@ -54,7 +53,7 @@ var runCmd = &cobra.Command{
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			fmt.Println(res)
+			fmt.Println(res.GetInstanceId())
 			return err
 		})
 	}}

--- a/cmd/openvdc/cmd/show.go
+++ b/cmd/openvdc/cmd/show.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/axsh/openvdc/api"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -57,15 +58,9 @@ var showCmd = &cobra.Command{
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			/*
-				buf, err := json.MarshalIndent(res, "", "  ")
-				if err != nil {
-					log.WithError(err).Fatal("Faild to format to pretty JSON.")
-				}
-				fmt.Println(string(buf))
-			*/
-			m := &proto.TextMarshaler{Compact: false}
-			m.Marshal(os.Stdout, res)
+			if err := (&jsonpb.Marshaler{Indent: "  "}).Marshal(os.Stdout, res); err != nil {
+				log.WithError(err).Fatal("Faild to format to pretty JSON.")
+			}
 			return err
 		})
 	},

--- a/cmd/openvdc/cmd/start.go
+++ b/cmd/openvdc/cmd/start.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/axsh/openvdc/api"
 	"github.com/axsh/openvdc/cmd/openvdc/internal/util"
@@ -27,12 +25,11 @@ var startCmd = &cobra.Command{
 		}
 		return util.RemoteCall(func(conn *grpc.ClientConn) error {
 			c := api.NewInstanceClient(conn)
-			res, err := c.Start(context.Background(), req)
+			_, err := c.Start(context.Background(), req)
 			if err != nil {
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			fmt.Println(res)
 			return err
 		})
 	}}

--- a/cmd/openvdc/cmd/stop.go
+++ b/cmd/openvdc/cmd/stop.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/axsh/openvdc/api"
@@ -31,12 +29,11 @@ var stopCmd = &cobra.Command{
 		return util.RemoteCall(func(conn *grpc.ClientConn) error {
 			c := api.NewInstanceClient(conn)
 
-			res, err := c.Stop(context.Background(), req)
+			_, err := c.Stop(context.Background(), req)
 			if err != nil {
 				log.WithError(err).Fatal("Disconnected abnormally")
 				return err
 			}
-			fmt.Println(res)
 			return err
 		})
 	},

--- a/cmd/openvdc/cmd/unregister.go
+++ b/cmd/openvdc/cmd/unregister.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
@@ -27,12 +25,11 @@ var unregisterCmd = &cobra.Command{
 		}
 		return util.RemoteCall(func(conn *grpc.ClientConn) error {
 			c := api.NewResourceClient(conn)
-			res, err := c.Unregister(context.Background(), &api.ResourceIDRequest{Key: &api.ResourceIDRequest_ID{ID: resourceID}})
+			_, err := c.Unregister(context.Background(), &api.ResourceIDRequest{Key: &api.ResourceIDRequest_ID{ID: resourceID}})
 			if err != nil {
 				log.WithError(err).Fatal("Disconnected abnormaly")
 				return err
 			}
-			fmt.Println(res)
 			return err
 		})
 	},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -52,6 +52,12 @@
 			"revisionTime": "2016-01-25T20:49:56Z"
 		},
 		{
+			"checksumSHA1": "APDDi2ohrU7OkChQCekD9tSVUhs=",
+			"path": "github.com/golang/protobuf/jsonpb",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",


### PR DESCRIPTION
- [x] ``openvdc show`` shows data in JSON by using protobuf's jsonpb.
    - Allows Timestamp object in formatted string.

```bash
$ ./openvdc show i-0000000000
{
  "ID": "i-0000000000",
  "instance": {
    "id": "i-0000000000",
    "resourceId": "r-0000000000",
    "lastState": {
      "state": "QUEUED",
      "createdAt": "2017-01-09T08:54:12.791662301Z"
    }
  }
```
- [x] Print ID only: ``openvdc create``, ``openvdc register``, ``openvdc run``
    - Helps shell scripting. i.e. ``ID=$(openvdc create)``
- [x] No print: ``openvdc start``, ``openvdc stop``, ``openvdc destroy``
- ~~Fix output from logruns on windows~~ => Next PR.
```
PS > .\openvdc help
time="2017-01-10T17:48:28+09:00" level=fatal msg="Failed to load config : Config File \"config\" Not Found in \"[C:\\\\Users\\\\katsuo\\\\.openvdc]\""
```