### PR TITLE
CI merge master locally fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ node() {
     // http://stackoverflow.com/questions/36507410/is-it-possible-to-capture-the-stdout-from-the-sh-dsl-command-in-the-pipeline
     // https://issues.jenkins-ci.org/browse/JENKINS-26133
     RELEASE_SUFFIX=sh(returnStdout: true, script: "./deployment/packagebuild/gen-dev-build-tag.sh").trim()
-    SHA=sh(returnStdout: true, "git rev-parse --verify HEAD").trim()
+    SHA=sh(returnStdout: true, script: "git rev-parse --verify HEAD").trim()
 }
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ RELEASE_SUFFIX=${RELEASE_SUFFIX}
 GIT_BRANCH=${env.BRANCH_NAME}
 BRANCH_NAME=${env.BRANCH_NAME}
 BRANCH=${env.BRANCH_NAME}
+SHA=${env.SHA}
 """
   writeFile(file: "build.env", text: build_env)
 }
@@ -90,10 +91,11 @@ node() {
     }catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException err) {
       // Only ignore errors for timeout.
     }
-    checkout_and_merge()
+    checkout scm
     // http://stackoverflow.com/questions/36507410/is-it-possible-to-capture-the-stdout-from-the-sh-dsl-command-in-the-pipeline
     // https://issues.jenkins-ci.org/browse/JENKINS-26133
     RELEASE_SUFFIX=sh(returnStdout: true, script: "./deployment/packagebuild/gen-dev-build-tag.sh").trim()
+    SHA=sh(returnStdout: true, "git rev-parse --verify HEAD").trim()
 }
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ SHA=${SHA}
 
 def checkout_and_merge() {
     checkout scm
-    sh "git merge origin/master"
+    sh "git -c \"user.name=Axsh Bot\" -c \"user.email=dev@axsh.net\" merge origin/master"
 }
 
 @Field RELEASE_SUFFIX=null

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ def checkout_and_merge() {
 }
 
 @Field RELEASE_SUFFIX=null
+@Field SHA=null
 
 def stage_unit_test(label) {
   node(label) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ RELEASE_SUFFIX=${RELEASE_SUFFIX}
 GIT_BRANCH=${env.BRANCH_NAME}
 BRANCH_NAME=${env.BRANCH_NAME}
 BRANCH=${env.BRANCH_NAME}
-SHA=${env.SHA}
+SHA=${SHA}
 """
   writeFile(file: "build.env", text: build_env)
 }

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,9 @@
 set -xe
 
 VERSION=${VERSION:-"dev"}
-SHA=$(git rev-parse --verify HEAD)
+if [[ -z "${SHA}" ]]; then
+  SHA=${SHA:-(git rev-parse --verify HEAD)}
+fi
 BUILDDATE=$(date '+%Y/%m/%d %H:%M:%S %Z')
 GOVERSION=$(go version)
 BUILDSTAMP="github.com/axsh/openvdc"


### PR DESCRIPTION
The way merging before build was implemented introduced a problem where the RELEASE_SUFFIX would hold a different commit than the one on github. This also broke the OpenVDC templates repository.

This PR fixes the former and maybe fixes the latter. Whether or not the latter is really fixed will be shown by the integration test soon.