### PR TITLE
build: Fix break in #67.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,7 @@
 set -xe
 
 VERSION=${VERSION:-"dev"}
-if [[ -z "${SHA}" ]]; then
-  SHA=${SHA:-(git rev-parse --verify HEAD)}
-fi
+SHA=${SHA:-$(git rev-parse --verify HEAD)}
 BUILDDATE=$(date '+%Y/%m/%d %H:%M:%S %Z')
 GOVERSION=$(go version)
 BUILDSTAMP="github.com/axsh/openvdc"


### PR DESCRIPTION
Running ``build.sh`` on desktop does not set SHA value. 

```
$ ./openvdc version
openvdc version dev (git: (git rev, build: 2017/01/11 15:00:33 JST, goversion: go version go1.7.4 darwin/amd64)
```

Caused by #67.
