### PR TITLE
Ensure to run the teardown steps for ci-multi cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,11 +75,14 @@ def stage_integration(label) {
     stage "Build Integration Environment"
     write_build_env(label)
 
-    sh "cd ci/multibox/ ; ./build.sh"
-    stage "Run Tntegration Test"
-    // This is where the integration test will be run
-    stage "Cleanup Environment"
-    sh "cd ci/multibox/ ; ./destroy.sh --kill"
+    try {
+      sh "cd ci/multibox/ ; ./build.sh"
+      stage "Run Tntegration Test"
+      // This is where the integration test will be run
+    } finally {
+      stage "Cleanup Environment"
+      sh "cd ci/multibox/ ; ./destroy.sh --kill"
+    }
   }
 }
 

--- a/ci/multibox/config.source
+++ b/ci/multibox/config.source
@@ -1,3 +1,4 @@
+#!/bin/bash
 # The nodes to build. If any of these are replaced by a physical device,
 # comment it out here.
 NODES=(

--- a/ci/multibox/ind-steps/common.source
+++ b/ci/multibox/ind-steps/common.source
@@ -60,7 +60,7 @@ function stop_masquerade() {
     [ "$?" != "0" ]
     $skip_step_if_already_done; set +e
     sudo iptables -t nat -D POSTROUTING -s "${subnet}" -j MASQUERADE
-  )
+  ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 }
 
 function run_steps () {
@@ -134,7 +134,7 @@ function destroy_bridge() {
     # Ignore errors for complete teardown.
     sudo ip link set "${1}" down
     sudo brctl delbr "${1}"
-  )
+  ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 }
 
 function require_branch_variable() {

--- a/ci/multibox/ind-steps/common.source
+++ b/ci/multibox/ind-steps/common.source
@@ -58,9 +58,9 @@ function stop_masquerade() {
     $starting_step "Stop masquerading for subnet ${subnet}"
     sudo iptables-save | grep -wq "\-A POSTROUTING \-s ${subnet} \-j MASQUERADE"
     [ "$?" != "0" ]
-    $skip_step_if_already_done
+    $skip_step_if_already_done; set +e
     sudo iptables -t nat -D POSTROUTING -s "${subnet}" -j MASQUERADE
-  ) ; prev_cmd_failed
+  )
 }
 
 function run_steps () {
@@ -123,8 +123,9 @@ function destroy_bridge() {
     $starting_step "Destroy bridge ${name}"
     brctl show | grep -q "${name}"
     [ "$?" != "0" ]
-    $skip_step_if_already_done ; set -xe
+    $skip_step_if_already_done ; set -x +e
+    # Ignore errors for complete teardown.
     sudo ip link set "${1}" down
     sudo brctl delbr "${1}"
-  ) ; prev_cmd_failed
+  )
 }

--- a/ci/multibox/ind-steps/step-box/common.source
+++ b/ci/multibox/ind-steps/step-box/common.source
@@ -18,17 +18,17 @@ function kill_vm() {
     (
         $starting_step "Kill vm ${vm_name}"
         [[ ! -f "${NODE_DIR}/${vm_name}.pid" ]]
-        $skip_step_if_already_done; set -x
+        $skip_step_if_already_done; set -x +e
         sudo kill $(sudo cat "${NODE_DIR}/${vm_name}.pid")
         sudo rm "${NODE_DIR}/${vm_name}.pid"
-    ) ; $prev_cmd_failed
+    )
 
     (
         $starting_step "Remove copy-on-write image"
         [ ! -f "${NODE_DIR}/${vm_name}.qcow2" ]
-        $skip_step_if_already_done ; set -x
+        $skip_step_if_already_done ; set -x +e
         rm "${NODE_DIR}/${vm_name}.qcow2"
-    ) ; prev_cmd_failed
+    )
 }
 
 function destroy_vm() {
@@ -37,15 +37,36 @@ function destroy_vm() {
         [ ! -f ${NODE_DIR}/sshkey ]
         $skip_step_if_already_done
         rm ${NODE_DIR}/sshkey
-    ) ; prev_cmd_failed
+    )
     kill_vm
     (
         $starting_step "Remove base image ${vm_name}"
         [ ! -f "$(cache_image)" ]
-        $skip_step_if_already_done; set -x
+        $skip_step_if_already_done; set -x +e
         [[ -f "${CACHE_DIR}/${BRANCH}/sshkey_${vm_name}" ]] && rm "${CACHE_DIR}/${BRANCH}/sshkey_${vm_name}"*
         rm "$(cache_image)"
-    ) ; $prev_cmd_failed
+    )
+    local i
+    for (( i=0 ; i < ${#nics[@]} ; i++ )) ; do
+      nic=(${nics[$i]})
+      # Attach tap device to bridge if bridge= was provided
+      [[ -z "${nic[2]#*=}" ]] || {
+          (
+              $starting_step "Attach ${nic[0]#*=} to ${nic[2]#*=}"
+              ! (brctl show ${nic[2]#*=} | grep -wq ${nic[0]#*=})
+              $skip_step_if_already_done; set -x +e
+              sudo brctl delif ${nic[2]#*=} ${nic[0]#*=}
+          )
+      }
+      (
+        ifname="${nic[0]#*=}"
+        $starting_step "Destroy ${ifname}"
+        ! ip link show dev "${ifname}"
+        $skip_step_if_already_done; set -x +e
+        sudo ip link set dev "${ifname}" down
+        sudo ip link delete dev "${ifname}"
+      )
+    done
 }
 
 function umount-seed-image() {
@@ -53,7 +74,7 @@ function umount-seed-image() {
         $starting_step "Unmount temporary root folder for ${vm_name}"
         mount | grep -q "${TMP_ROOT}"
         [ "$?" != "0" ]
-        $skip_step_if_already_done
+        $skip_step_if_already_done; set -x +e
         umount-partition --sudo "${TMP_ROOT}"
         rmdir "${TMP_ROOT}"
     ) ; prev_cmd_failed

--- a/ci/multibox/ind-steps/step-box/common.source
+++ b/ci/multibox/ind-steps/step-box/common.source
@@ -21,14 +21,14 @@ function destroy_vm() {
         $skip_step_if_already_done; set -x +e
         sudo kill $(sudo cat "${NODE_DIR}/${vm_name}.pid")
         sudo rm -f "${NODE_DIR}/${vm_name}.pid"
-    )
+    ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 
     (
         $starting_step "Remove copy-on-write image"
         [ ! -f "${NODE_DIR}/${vm_name}.qcow2" ]
         $skip_step_if_already_done ; set -x +e
         rm -f "${NODE_DIR}/${vm_name}.qcow2"
-    )
+    ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
     local i
     for (( i=0 ; i < ${#nics[@]} ; i++ )) ; do
       nic=(${nics[$i]})
@@ -39,7 +39,7 @@ function destroy_vm() {
               ! (brctl show ${nic[2]#*=} | grep -wq ${nic[0]#*=})
               $skip_step_if_already_done; set -x +e
               sudo brctl delif ${nic[2]#*=} ${nic[0]#*=}
-          )
+          ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
       }
       (
         ifname="${nic[0]#*=}"
@@ -48,7 +48,7 @@ function destroy_vm() {
         $skip_step_if_already_done; set -x +e
         sudo ip link set dev "${ifname}" down
         sudo ip link delete dev "${ifname}"
-      )
+      ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
     done
 }
 
@@ -58,7 +58,7 @@ function destroy_vm_cache() {
         [ ! -f ${NODE_DIR}/sshkey ]
         $skip_step_if_already_done
         rm ${NODE_DIR}/sshkey
-    )
+    ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 
     (
         $starting_step "Remove base image ${vm_name}"
@@ -66,7 +66,7 @@ function destroy_vm_cache() {
         $skip_step_if_already_done; set -x +e
         rm -f "${CACHE_DIR}/${BRANCH}/sshkey_${vm_name}"*
         rm -f "$(cache_image)"
-    )
+    ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 }
 
 function umount-seed-image() {

--- a/ci/multibox/ind-steps/step-openvdc/common.source
+++ b/ci/multibox/ind-steps/step-openvdc/common.source
@@ -1,3 +1,4 @@
+#!/bin/bash
 scheduler=${scheduler:-false}
 mesos_master="${mesos_master:-10.0.100.11}"
 zk="${zk:-10.0.100.10}"

--- a/ci/multibox/ind-steps/step-zookeeper/common.source
+++ b/ci/multibox/ind-steps/step-zookeeper/common.source
@@ -1,1 +1,2 @@
+#!/bin/bash
 zk_host=${zk_host:-false}


### PR DESCRIPTION
Our integration test was failing sometime due to the garbage from the previous build.  ``Cleanup Environment`` Jenkins stage should run all the steps even if they met errors otherwise virtual machines for testing or network bridge remain on the server.

By wrapping the destroy script in ``finally`` block, the ci-multi cluster is wiped out when the building/testing job was canceled. 