### PR TITLE
Improve scheduler command options: --zk, --master

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/axsh/openvdc/model"
+	"github.com/axsh/openvdc/model/backend"
 	"google.golang.org/grpc"
 
 	sched "github.com/mesos/mesos-go/scheduler"
@@ -13,11 +14,11 @@ import (
 
 type APIServer struct {
 	server         *grpc.Server
-	modelStoreAddr []string
+	modelStoreAddr backend.ConnectionAddress
 	scheduler      sched.SchedulerDriver
 }
 
-func NewAPIServer(modelAddr []string, driver sched.SchedulerDriver) *APIServer {
+func NewAPIServer(modelAddr backend.ConnectionAddress, driver sched.SchedulerDriver) *APIServer {
 	sopts := []grpc.ServerOption{
 		// Setup request middleware for the model.backend database connection.
 		grpc.UnaryInterceptor(model.GrpcInterceptor(modelAddr)),

--- a/api/server.go
+++ b/api/server.go
@@ -13,11 +13,11 @@ import (
 
 type APIServer struct {
 	server         *grpc.Server
-	modelStoreAddr string
+	modelStoreAddr []string
 	scheduler      sched.SchedulerDriver
 }
 
-func NewAPIServer(modelAddr string, driver sched.SchedulerDriver) *APIServer {
+func NewAPIServer(modelAddr []string, driver sched.SchedulerDriver) *APIServer {
 	sopts := []grpc.ServerOption{
 		// Setup request middleware for the model.backend database connection.
 		grpc.UnaryInterceptor(model.GrpcInterceptor(modelAddr)),

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -6,11 +6,14 @@ import (
 	"time"
 
 	"github.com/axsh/openvdc/internal/unittest"
+	"github.com/axsh/openvdc/model/backend"
 )
 
 func TestNewAPIServer(t *testing.T) {
 	// TODO: Set mock SchedulerDriver
-	s := NewAPIServer(unittest.TestZkServer, nil)
+	ze := &backend.ZkEndpoint{}
+	ze.Set(unittest.TestZkServer)
+	s := NewAPIServer(ze, nil)
 	if s == nil {
 		t.Error("NewAPIServer() returned nil")
 	}
@@ -22,7 +25,9 @@ func TestAPIServerRun(t *testing.T) {
 		t.Error(err)
 	}
 	// TODO: Set mock SchedulerDriver
-	s := NewAPIServer(unittest.TestZkServer, nil)
+	ze := &backend.ZkEndpoint{}
+	ze.Set(unittest.TestZkServer)
+	s := NewAPIServer(ze, nil)
 	go func() {
 		time.Sleep(2 * time.Second)
 		s.Stop()

--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/axsh/openvdc/hypervisor"
 	"github.com/axsh/openvdc/model"
+	"github.com/axsh/openvdc/model/backend"
 	mesosutil "github.com/mesos/mesos-go/mesosutil"
 	"golang.org/x/net/context"
 )
@@ -77,7 +78,7 @@ func (exec *VDCExecutor) bootInstance(driver exec.ExecutorDriver, taskInfo *meso
 		"hypervisor":  exec.hypervisorProvider.Name(),
 	})
 
-	ctx, err := model.Connect(context.Background(), []string{*zkAddr})
+	ctx, err := model.Connect(context.Background(), &zkAddr)
 	if err != nil {
 		log.WithError(err).Error("Failed model.Connect")
 		return err
@@ -140,7 +141,7 @@ func (exec *VDCExecutor) startInstance(driver exec.ExecutorDriver, instanceID st
 		"hypervisor":  exec.hypervisorProvider.Name(),
 	})
 
-	ctx, err := model.Connect(context.Background(), []string{*zkAddr})
+	ctx, err := model.Connect(context.Background(), &zkAddr)
 	if err != nil {
 		log.WithError(err).Error("Failed model.Connect")
 		return err
@@ -185,7 +186,7 @@ func (exec *VDCExecutor) stopInstance(driver exec.ExecutorDriver, instanceID str
 		"hypervisor":  exec.hypervisorProvider.Name(),
 	})
 
-	ctx, err := model.Connect(context.Background(), []string{*zkAddr})
+	ctx, err := model.Connect(context.Background(), &zkAddr)
 	if err != nil {
 		log.WithError(err).Error("Failed model.Connect")
 		return err
@@ -230,7 +231,7 @@ func (exec *VDCExecutor) terminateInstance(driver exec.ExecutorDriver, instanceI
 		"hypervisor":  exec.hypervisorProvider.Name(),
 	})
 
-	ctx, err := model.Connect(context.Background(), []string{*zkAddr})
+	ctx, err := model.Connect(context.Background(), &zkAddr)
 	if err != nil {
 		log.WithError(err).Error("Failed model.Connect")
 		return err
@@ -347,10 +348,12 @@ func (exec *VDCExecutor) Error(driver exec.ExecutorDriver, err string) {
 
 var (
 	hypervisorName = flag.String("hypervisor", "null", "")
-	zkAddr         = flag.String("zk", "127.0.0.1:2181", "Zookeeper address")
 )
+var zkAddr backend.ZkEndpoint
 
 func init() {
+	zkAddr = backend.ZkEndpoint{Hosts: []string{"127.0.0.1:2181"}, Path: "/openvdc"}
+	flag.Var(&zkAddr, "zk", "Zookeeper address")
 	flag.Parse()
 }
 

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -28,9 +28,20 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "openvdc-scheduler",
-	Short: "",
+	Short: "Run openvdc-scheduler process",
 	Long:  ``,
-	Run:   execute,
+	Example: `
+	"--zk" and "--master" may be one of:
+	  "host:port"
+		"zk://host1:port1,host2:port2,.../path"
+
+	Auto detect mesos cluster from Zookeeper.
+	% openvdc-scheduler --master=zk://localhost/mesos --zk=zk://192.168.1.10
+
+  Explicitly specify the mesos master address.
+	% openvdc-scheduler --master=localhost:5050 --zk=localhost:2181
+	`,
+	Run: execute,
 }
 var gRPCAddr string
 var mesosMasterAddr string

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -38,9 +38,9 @@ var listenAddr string
 var zkAddr ZkEndpoint
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&mesosMasterAddr, "master", "", "localhost:5050", "Mesos Master node address")
 	zkAddr = ZkEndpoint{Hosts: []string{"localhost"}, Path: "/openvdc"}
 
+	rootCmd.PersistentFlags().StringVarP(&mesosMasterAddr, "master", "", "zk://localhost/mesos", "Mesos Master node address")
 	rootCmd.PersistentFlags().StringVarP(&gRPCAddr, "api", "a", "localhost:5000", "gRPC API bind address")
 	rootCmd.PersistentFlags().StringVarP(&listenAddr, "listen", "l", "0.0.0.0", "Local bind address")
 	rootCmd.PersistentFlags().VarP(&zkAddr, "zk", "", "Zookeeper node address")

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -57,7 +57,7 @@ func init() {
 func setupDatabaseSchema() {
 	ctx, err := model.Connect(context.Background(), &zkAddr)
 	if err != nil {
-		log.WithError(err).Fatalf("Could not connect to database: %s", zkAddr)
+		log.WithError(err).Fatalf("Could not connect to database: %s", zkAddr.String())
 	}
 	defer model.Close(ctx)
 	ms, ok := model.GetBackendCtx(ctx).(backend.ModelSchema)

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -3,14 +3,17 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
-
 	"github.com/axsh/openvdc"
 	"github.com/axsh/openvdc/model"
 	"github.com/axsh/openvdc/model/backend"
 	"github.com/axsh/openvdc/scheduler"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 )
@@ -32,18 +35,20 @@ var rootCmd = &cobra.Command{
 var gRPCAddr string
 var mesosMasterAddr string
 var listenAddr string
-var zkAddr string
+var zkAddr ZkEndpoint
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&mesosMasterAddr, "master", "", "localhost:5050", "Mesos Master node address")
+	zkAddr = ZkEndpoint{Hosts: []string{"localhost"}, Path: "/openvdc"}
+
 	rootCmd.PersistentFlags().StringVarP(&gRPCAddr, "api", "a", "localhost:5000", "gRPC API bind address")
 	rootCmd.PersistentFlags().StringVarP(&listenAddr, "listen", "l", "0.0.0.0", "Local bind address")
-	rootCmd.PersistentFlags().StringVarP(&zkAddr, "zk", "", "127.0.0.1", "Zookeeper node address")
+	rootCmd.PersistentFlags().VarP(&zkAddr, "zk", "", "Zookeeper node address")
 	rootCmd.PersistentFlags().SetAnnotation("master", cobra.BashCompSubdirsInDir, []string{})
 }
 
 func setupDatabaseSchema() {
-	ctx, err := model.Connect(context.Background(), []string{zkAddr})
+	ctx, err := model.Connect(context.Background(), zkAddr.Hosts)
 	if err != nil {
 		log.WithError(err).Fatalf("Could not connect to database: %s", zkAddr)
 	}
@@ -59,9 +64,44 @@ func setupDatabaseSchema() {
 	}
 }
 
+type ZkEndpoint struct {
+	Path  string
+	Hosts []string // "host" or "host:port"
+}
+
+func (ze *ZkEndpoint) String() string {
+	return fmt.Sprintf("zk://%s%s", strings.Join(ze.Hosts, ","), ze.Path)
+}
+
+func (ze *ZkEndpoint) Set(value string) error {
+	if strings.HasPrefix(value, "zk://") {
+		zkurl, err := url.Parse(value)
+		if err != nil {
+			return errors.Wrap(err, "Invalid zk URL")
+		}
+		ze.Hosts = strings.Split(zkurl.Host, ",")
+		ze.Path = zkurl.Path
+	} else {
+		host, port, err := net.SplitHostPort(value)
+		if err != nil {
+			host = value
+			port = "2181"
+		}
+		if host == "" {
+			host = "localhost"
+		}
+		ze.Hosts = []string{net.JoinHostPort(host, port)}
+	}
+	return nil
+}
+
+func (ZkEndpoint) Type() string {
+	return "ZkEndpoint"
+}
+
 func execute(cmd *cobra.Command, args []string) {
 	setupDatabaseSchema()
-	scheduler.Run(listenAddr, gRPCAddr, mesosMasterAddr, zkAddr)
+	scheduler.Run(listenAddr, gRPCAddr, mesosMasterAddr, zkAddr.Hosts)
 }
 
 func main() {

--- a/model/backend/bolt.go
+++ b/model/backend/bolt.go
@@ -1,6 +1,10 @@
 package backend
 
-import "github.com/boltdb/bolt"
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+)
 
 type Bolt struct {
 	db       *bolt.DB
@@ -13,11 +17,21 @@ func NewBoltBackend() *Bolt {
 	}
 }
 
-func (b *Bolt) Connect(dest []string) error {
+type BoltDBPath string
+
+func (BoltDBPath) isConnectionAddress() {}
+
+func (b BoltDBPath) String() string { return string(b) }
+
+func (b *Bolt) Connect(dest ConnectionAddress) error {
 	if b.db != nil {
 		return ErrConnectionExists
 	}
-	db, err := bolt.Open(dest[0], 0644, nil)
+	path, ok := dest.(BoltDBPath)
+	if !ok {
+		return fmt.Errorf("Invalid connection address type: %T", dest)
+	}
+	db, err := bolt.Open(path.String(), 0644, nil)
 	if err != nil {
 		return err
 	}

--- a/model/backend/bolt_test.go
+++ b/model/backend/bolt_test.go
@@ -16,7 +16,7 @@ func TestBoltConnect(t *testing.T) {
 	assert := assert.New(t)
 	z := NewBoltBackend()
 	defer z.Close()
-	err := z.Connect([]string{"my.db"})
+	err := z.Connect(BoltDBPath("my.db"))
 	assert.NoError(err)
 }
 
@@ -24,7 +24,7 @@ func TestBoltCreate(t *testing.T) {
 	assert := assert.New(t)
 	z := NewBoltBackend()
 	defer z.Close()
-	err := z.Connect([]string{"my.db"})
+	err := z.Connect(BoltDBPath("my.db"))
 	assert.NoError(err)
 	err = z.Create("/test1", []byte{})
 	assert.NoError(err)

--- a/model/backend/types.go
+++ b/model/backend/types.go
@@ -13,8 +13,12 @@ type KeyIterator interface {
 	Value() string
 }
 
+type ConnectionAddress interface {
+	isConnectionAddress()
+}
+
 type ModelBackend interface {
-	Connect(dest []string) error
+	Connect(dest ConnectionAddress) error
 	Close() error
 	Create(key string, value []byte) error
 	CreateWithID(key string, value []byte) (string, error)

--- a/model/backend/zk.go
+++ b/model/backend/zk.go
@@ -79,9 +79,13 @@ func (z *Zk) Connect(dest ConnectionAddress) error {
 	if z.isConnected() {
 		return ErrConnectionExists
 	}
-	zkAddr, ok := dest.(*ZkEndpoint)
+	zkAddr, ok := dest.(ZkEndpoint)
 	if !ok {
-		return fmt.Errorf("Invalid connection address type: %T", dest)
+		p, ok := dest.(*ZkEndpoint)
+		if !ok {
+			return fmt.Errorf("Invalid connection address type: %T", dest)
+		}
+		zkAddr = *p
 	}
 	z.basePath = zkAddr.Path
 	c, ev, err := zk.Connect(zkAddr.Hosts, 10*time.Second)

--- a/model/connection.go
+++ b/model/connection.go
@@ -14,7 +14,7 @@ import (
 
 var ErrBackendNotInContext = errors.New("Given context does not have the backend object")
 
-func Connect(ctx context.Context, dest []string) (context.Context, error) {
+func Connect(ctx context.Context, dest backend.ConnectionAddress) (context.Context, error) {
 	bk := backend.NewZkBackend()
 	err := bk.Connect(dest)
 	if err != nil {
@@ -59,7 +59,7 @@ func GetBackendCtx(ctx context.Context) backend.ModelBackend {
 	return bk
 }
 
-func GrpcInterceptor(modelAddr []string) grpc.UnaryServerInterceptor {
+func GrpcInterceptor(modelAddr backend.ConnectionAddress) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		ctx, err := Connect(ctx, modelAddr)
 		if err != nil {

--- a/model/connection.go
+++ b/model/connection.go
@@ -59,9 +59,9 @@ func GetBackendCtx(ctx context.Context) backend.ModelBackend {
 	return bk
 }
 
-func GrpcInterceptor(modelAddr string) grpc.UnaryServerInterceptor {
+func GrpcInterceptor(modelAddr []string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		ctx, err := Connect(ctx, []string{modelAddr})
+		ctx, err := Connect(ctx, modelAddr)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to connect to model backend: %s", modelAddr)
 			return nil, err

--- a/model/connection_test.go
+++ b/model/connection_test.go
@@ -4,13 +4,19 @@ import (
 	"testing"
 
 	"github.com/axsh/openvdc/internal/unittest"
+	"github.com/axsh/openvdc/model/backend"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
 func TestConnect(t *testing.T) {
 	assert := assert.New(t)
-	ctx, err := Connect(context.Background(), []string{unittest.TestZkServer})
+
+	ze := &backend.ZkEndpoint{}
+	if err := ze.Set(unittest.TestZkServer); err != nil {
+		t.Fatal("Invalid zookeeper address:", unittest.TestZkServer)
+	}
+	ctx, err := Connect(context.Background(), ze)
 	assert.NoError(err)
 	assert.NotNil(ctx)
 	err = Close(ctx)

--- a/model/instances_test.go
+++ b/model/instances_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 func withConnect(t *testing.T, c func(context.Context)) error {
-
-	ctx, err := Connect(context.Background(), []string{unittest.TestZkServer})
+	ze := &backend.ZkEndpoint{}
+	if err := ze.Set(unittest.TestZkServer); err != nil {
+		t.Fatal("Invalid zookeeper address:", unittest.TestZkServer)
+	}
+	ctx, err := Connect(context.Background(), ze)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -157,7 +157,7 @@ func (sched *VDCScheduler) processOffers(driver sched.SchedulerDriver, offers []
 			Name:       proto.String("VDC Executor"),
 			Command: &mesos.CommandInfo{
 				Value: proto.String(fmt.Sprintf("%s -logtostderr=true -hypervisor=%s -zk=%s",
-					ExecutorPath, hypervisorName, sched.zkAddr)),
+					ExecutorPath, hypervisorName, sched.zkAddr.String())),
 			},
 		}
 

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/axsh/openvdc/api"
 	"github.com/axsh/openvdc/model"
+	"github.com/axsh/openvdc/model/backend"
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/auth"
 	"github.com/mesos/mesos-go/auth/sasl"
@@ -42,10 +43,10 @@ type VDCScheduler struct {
 	tasksErrored  int
 	totalTasks    int
 	listenAddr    string
-	zkAddr        []string
+	zkAddr        backend.ZkEndpoint
 }
 
-func newVDCScheduler(listenAddr string, zkAddr []string) *VDCScheduler {
+func newVDCScheduler(listenAddr string, zkAddr backend.ZkEndpoint) *VDCScheduler {
 	return &VDCScheduler{
 		totalTasks: taskCount,
 		listenAddr: listenAddr,
@@ -240,7 +241,7 @@ func (sched *VDCScheduler) Error(_ sched.SchedulerDriver, err string) {
 	log.Fatalf("Scheduler received error: %v", err)
 }
 
-func startAPIServer(laddr string, zkAddr []string, driver sched.SchedulerDriver) *api.APIServer {
+func startAPIServer(laddr string, zkAddr backend.ZkEndpoint, driver sched.SchedulerDriver) *api.APIServer {
 	lis, err := net.Listen("tcp", laddr)
 	if err != nil {
 		log.Fatalln("Faild to bind address for gRPC API: ", laddr)
@@ -251,7 +252,7 @@ func startAPIServer(laddr string, zkAddr []string, driver sched.SchedulerDriver)
 	return s
 }
 
-func Run(listenAddr string, apiListenAddr string, mesosMasterAddr string, zkAddr []string) {
+func Run(listenAddr string, apiListenAddr string, mesosMasterAddr string, zkAddr backend.ZkEndpoint) {
 	cred := &mesos.Credential{
 		Principal: proto.String(""),
 		Secret:    proto.String(""),

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/mesos-go/auth"
 	"github.com/mesos/mesos-go/auth/sasl"
+	_ "github.com/mesos/mesos-go/detector/zoo"
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	util "github.com/mesos/mesos-go/mesosutil"
 	sched "github.com/mesos/mesos-go/scheduler"


### PR DESCRIPTION
--zk and --master options are extended to support ``zk://`` URL syntax similar to the mesos --zk option. The URL allows to specify multiple zookeeper hosts.

```
zk://host1:port1,host2:port2/base
```

For --zk option, let go-zookeeper recover from a zookeeper node failure. 
For --master option, mesos-go detects mesos-master node endpoint from the zookeeper catalogue. It is required for the mesos multi master configuration.
