### PR TITLE
Scheduler local configuration file

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -65,6 +65,6 @@ if( $env:APPVEYOR_REPO_BRANCH ){
 $LDFLAGS="${LDFLAGS} -X '${BUILDSTAMP}.GithubDefaultRef=${branch}'"
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=C:\\openvdc\\etc\\scheduler.conf'" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 Write-Host "Done"

--- a/build.ps1
+++ b/build.ps1
@@ -65,6 +65,6 @@ if( $env:APPVEYOR_REPO_BRANCH ){
 $LDFLAGS="${LDFLAGS} -X '${BUILDSTAMP}.GithubDefaultRef=${branch}'"
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=C:\\openvdc\\etc\\scheduler.conf'" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=C:\\openvdc\\etc\\scheduler.toml'" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 Write-Host "Done"

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,6 @@ else
 fi
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=/etc/openvdc/scheduler.conf'" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 echo "Done"

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,6 @@ else
 fi
 
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc
-go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=/etc/openvdc/scheduler.conf'" -v ./cmd/openvdc-scheduler
+go build -ldflags "$LDFLAGS -X 'main.DefaultConfPath=/etc/openvdc/scheduler.toml'" -v ./cmd/openvdc-scheduler
 go build -ldflags "$LDFLAGS" -v ./cmd/openvdc-executor
 echo "Done"

--- a/pkg/conf/scheduler.toml
+++ b/pkg/conf/scheduler.toml
@@ -1,0 +1,9 @@
+[mesos]
+# master = "zk://localhost/mesos"
+# listen = "0.0.0.0"
+
+[zookeeper]
+# endpoint = "zk://localhost/openvdc"
+
+[api]
+# endpoint = "localhost:5000"

--- a/pkg/rhel/openvdc-scheduler.service
+++ b/pkg/rhel/openvdc-scheduler.service
@@ -1,9 +1,8 @@
 [Unit]
-Description=OpenVDc scheduler
+Description=OpenVDC scheduler
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/openvdc
 ExecStart=/opt/axsh/openvdc/bin/openvdc-scheduler 
 
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -55,9 +55,6 @@ cp openvdc-executor "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp openvdc-scheduler "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp ci/acceptance-test/tests/openvdc-acceptance-test "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp pkg/rhel/openvdc-scheduler.service "$RPM_BUILD_ROOT"%{_unitdir}
-mkdir -p "$RPM_BUILD_ROOT"/etc/sysconfig
-cp pkg/rhel/sysconfig-openvdc "$RPM_BUILD_ROOT"/etc/sysconfig/openvdc
-
 
 %package cli
 Summary: OpenVDC cli
@@ -70,7 +67,6 @@ The OpenVDC commandline interface.
 %dir /opt/axsh/openvdc/bin
 /usr/bin/openvdc
 /opt/axsh/openvdc/bin/openvdc
-%config(noreplace) /etc/sysconfig/openvdc
 
 %package executor
 Summary: OpenVDC executor

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -56,7 +56,7 @@ cp openvdc-scheduler "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp ci/acceptance-test/tests/openvdc-acceptance-test "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp pkg/rhel/openvdc-scheduler.service "$RPM_BUILD_ROOT"%{_unitdir}
 mkdir -p "${RPM_BUILD_ROOT}/etc/openvdc"
-cp pkg/conf/ "${RPM_BUILD_ROOT}/etc/openvdc"
+cp pkg/conf/scheduler.toml "${RPM_BUILD_ROOT}/etc/openvdc/"
 
 %package cli
 Summary: OpenVDC cli

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -55,6 +55,8 @@ cp openvdc-executor "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp openvdc-scheduler "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp ci/acceptance-test/tests/openvdc-acceptance-test "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp pkg/rhel/openvdc-scheduler.service "$RPM_BUILD_ROOT"%{_unitdir}
+mkdir -p "${RPM_BUILD_ROOT}/etc/openvdc"
+cp pkg/conf/ "${RPM_BUILD_ROOT}/etc/openvdc"
 
 %package cli
 Summary: OpenVDC cli
@@ -91,7 +93,7 @@ This is a 'stub'. An appropriate message must be substituted at some point.
 %dir /opt/axsh/openvdc/bin
 /opt/axsh/openvdc/bin/openvdc-scheduler
 %{_unitdir}/openvdc-scheduler.service
-
+%config(noreplace) /etc/openvdc/scheduler.toml
 
 %post
 %{systemd_post openvdc-scheduler.service}


### PR DESCRIPTION
Support scheduler's local configuration file. 

```
/etc/openvdc/scheduler.toml
```

``--config`` option loads the conf file from another location.

```
openvdc-scheduler--config=/var/tmp/custom.toml
```