### PR TITLE
Reinstate master cache reuse

### DIFF
--- a/ci/acceptance-test/README.md
+++ b/ci/acceptance-test/README.md
@@ -65,11 +65,17 @@ This environment uses a caching system to avoid having to constantly rebuild the
 
 #### First time run on a branch
 
+**If REBUILD != "true" (default)**
+
+* Copy cache from the master branch and use them as cache for the branch we're testing.
+
+**If REBUILD == "true" (to be used if the CI environment changed)**
+
 * Build images in .raw format **without** openvdc installed. We use .raw so we can loopback mount and install packages using chroot.
 
 * Convert images to .qcow format so we can use copy-on-write.
 
-* Store images in cache directory.
+* Store images in the branch's cache directory.
 
 #### Every time we run on a branch
 

--- a/ci/acceptance-test/multibox/build.sh
+++ b/ci/acceptance-test/multibox/build.sh
@@ -58,8 +58,8 @@ if [[ "$REBUILD" == "true" ]]; then
     (
         $starting_group "Cleanup old environment"
         [ ! -d "${CACHE_DIR}/${BRANCH}" ]
-        $skip_group_if_unnecessary
-        rm -rf "${CACHE_DIR}/${BRANCH}"
+        $skip_group_if_unnecessary; set -x
+        rm -rf ${CACHE_DIR}/${BRANCH}/*
         for node in ${scheduled_nodes[@]} ; do
             (
                 $starting_group "Destroying ${node%,*}"
@@ -69,14 +69,15 @@ if [[ "$REBUILD" == "true" ]]; then
             ) ; prev_cmd_failed
         done
     ) ; prev_cmd_failed
+else
+    (
+        $starting_step "Copy cache from ${BASE_BRANCH} branch"
+        [ -d "${CACHE_DIR}/${BRANCH}" ]
+        $skip_step_if_already_done
+        mkdir -p "${CACHE_DIR}/${BRANCH}"
+        rsync -av "${CACHE_DIR}/${BASE_BRANCH}/" "${CACHE_DIR}/${BRANCH}/"
+    ) ; prev_cmd_failed
 fi
-
-(
-    $starting_step "Create cache folder"
-    [ -d "${CACHE_DIR}/${BRANCH}" ]
-    $skip_step_if_already_done ; set -ex
-    mkdir -p "${CACHE_DIR}/${BRANCH}"
-) ; prev_cmd_failed
 
 masquerade "${NETWORK}/${PREFIX}"
 

--- a/ci/acceptance-test/multibox/build.sh
+++ b/ci/acceptance-test/multibox/build.sh
@@ -71,10 +71,16 @@ if [[ "$REBUILD" == "true" ]]; then
     ) ; prev_cmd_failed
 else
     (
-        $starting_step "Copy cache from ${BASE_BRANCH} branch"
+        $starting_step "Create cache folder"
         [ -d "${CACHE_DIR}/${BRANCH}" ]
-        $skip_step_if_already_done
+        $skip_step_if_already_done ; set -ex
         mkdir -p "${CACHE_DIR}/${BRANCH}"
+    ) ; prev_cmd_failed
+
+    (
+        $starting_step "Copy cache from ${BASE_BRANCH} branch"
+        [ ! -d "${CACHE_DIR}/${BASE_BRANCH}" ]
+        $skip_step_if_already_done
         rsync -av "${CACHE_DIR}/${BASE_BRANCH}/" "${CACHE_DIR}/${BRANCH}/"
     ) ; prev_cmd_failed
 fi

--- a/ci/acceptance-test/multibox/config.source
+++ b/ci/acceptance-test/multibox/config.source
@@ -16,5 +16,9 @@ BOXES=(
     "minimal-7.2.1511-x86_64.kvm.box"
 )
 
+# When a branch is built for the first time it will copy the cache from this branch
+# unless the REBUILD flag is set
+BASE_BRANCH="${BASE_BRANCH:-master}"
+
 BOXES_DIR="/data/openvdc-ci/boxes"
 CACHE_DIR="/data/openvdc-ci/branches"


### PR DESCRIPTION
Solves https://github.com/axsh/openvdc/issues/89. Copy paste from that issue:

### Problem

There was code in place to use the acceptance test cache for the master branch when building a new branch and the REBUILD variable isn't set.

I temporarily disabled that code because I wrongly assumed that we couldn't set the REBUILD variable manually while the CI is still kicked off automatically

### Solution

Re-enable that code.