### PR TITLE
Fix break after #91 and #94

### DIFF
--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -386,12 +386,16 @@ func initConfig() {
 }
 
 func init() {
+	// Initialize golang/glog flags used by mesos-go.
 	flag.CommandLine.Parse([]string{})
+	flag.Set("logtostderr", "true")
 }
 
 func execute(cmd *cobra.Command, args []string) {
-	var zkAddr backend.ZkEndpoint
-	zkAddr.Set(viper.GetString("zookeeper.endpoint"))
+	err := zkAddr.Set(viper.GetString("zookeeper.endpoint"))
+	if err != nil {
+		log.WithError(err).Fatal("Invalid zookeeper endpoint: ", viper.GetString("zookeeper.endpoint"))
+	}
 
 	provider, ok := hypervisor.FindProvider(viper.GetString("hypervisor.driver"))
 	if ok == false {

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -156,7 +156,7 @@ func (sched *VDCScheduler) processOffers(driver sched.SchedulerDriver, offers []
 			ExecutorId: util.NewExecutorID(fmt.Sprintf("vdc-hypervisor-%s", hypervisorName)),
 			Name:       proto.String("VDC Executor"),
 			Command: &mesos.CommandInfo{
-				Value: proto.String(fmt.Sprintf("%s -logtostderr=true -hypervisor=%s -zk=%s",
+				Value: proto.String(fmt.Sprintf("%s --hypervisor=%s --zk=%s",
 					ExecutorPath, hypervisorName, sched.zkAddr.String())),
 			},
 		}


### PR DESCRIPTION
``spf13/cobra`` option parser was enabled in #91 but std ``flags`` option parser was used by the sub-dependency ``golang/glog``. Those two are incompatible for the command line option syntax so that executor failed at the option parsing stage.

Fixes:

- [x] ``-logtostderr`` option for ``glog`` is mandate to dump logs from ``mesos-go`` to mesos-slave. Set the fixed value to the flag and skip option parsing by std ``flag``. 
- [x] ``openvdc-scheduler`` was sending ``-option`` style to executor. Update to ``--option``.

