### PR TITLE
Prevent the same offerId from being used more than once.

### DIFF
--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -114,6 +114,7 @@ func (sched *VDCScheduler) processOffers(driver sched.SchedulerDriver, offers []
 			if hypervisorName == "" {
 				continue
 			}
+
 			r, err := i.Resource(ctx)
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
@@ -143,9 +144,16 @@ func (sched *VDCScheduler) processOffers(driver sched.SchedulerDriver, offers []
 	acceptIDs := []*mesos.OfferID{}
 	for _, i := range queued {
 		found := findMatching(i)
+		for i, _ := range acceptIDs {
+			if acceptIDs[i] == found.Id {
+				found = nil
+			}
+		}
+
 		if found == nil {
 			continue
 		}
+
 		hypervisorName := getHypervisorName(found)
 		log.WithFields(log.Fields{
 			"instance_id": i.GetId(),


### PR DESCRIPTION
So if `./openvdc run centos/7/lxc` was run fast enough for both tasks to try to get started at the same time and they both shared the same offerId, it caused this error forever:

```
INFO[0403] Framework Resource Offers from master &TaskStatus{TaskId:&TaskID{Value:*i-0000000000,XXX_unrecognized:[],},
State:*TASK_LOST,Data:nil,Message:*Task launched with invalid offers: Duplicate offer d7686570-5257-45aa-8264-831618c4a086-O1018 in offer list,
SlaveId:&SlaveID{Value:*d7686570-5257-45aa-8264-831618c4a086-S0,XXX_unrecognized:[],},Timestamp:*1.48601637391366e+09,
ExecutorId:nil,Healthy:nil,Source:*SOURCE_MASTER,Reason:*REASON_INVALID_OFFERS,Uuid:nil,Labels:nil,ContainerStatus:nil,XXX_unrecognized:[],} 

INFO[0403] Framework Resource Offers from master &TaskStatus{TaskId:&TaskID{Value:*i-0000000001,XXX_unrecognized:[],},
State:*TASK_LOST,Data:nil,Message:*Task launched with invalid offers: Duplicate offer d7686570-5257-45aa-8264-831618c4a086-O1018 in offer list,
SlaveId:&SlaveID{Value:*d7686570-5257-45aa-8264-831618c4a086-S0,XXX_unrecognized:[],},Timestamp:*1.486016373914083e+09,
ExecutorId:nil,Healthy:nil,Source:*SOURCE_MASTER,Reason:*REASON_INVALID_OFFERS,Uuid:nil,Labels:nil,ContainerStatus:nil,XXX_unrecognized:[],} 
```

So even though multiple tasks can be launched at the same time with driver.LaunchTasks() it appears as if they aren't allowed to share the same offerID or am I missing something here? Anyway, as a quick fix to this problem I simply added a check that prevents offerIDs from being used more than once.