### PR TITLE
Fix #110

### DIFF
--- a/registry/github.go
+++ b/registry/github.go
@@ -231,10 +231,15 @@ func unzip(archive, target string) error {
 		return err
 	}
 
+	atime := time.Now()
 	for _, file := range reader.File {
 		path := filepath.Join(target, file.Name)
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(path, file.Mode())
+			err := os.MkdirAll(path, file.Mode())
+			if err != nil {
+				return err
+			}
+			os.Chtimes(path, atime, file.ModTime())
 			continue
 		}
 
@@ -253,6 +258,7 @@ func unzip(archive, target string) error {
 		if _, err := io.Copy(targetFile, fileReader); err != nil {
 			return err
 		}
+		os.Chtimes(path, atime, file.ModTime())
 	}
 
 	return nil


### PR DESCRIPTION
os.Rename() was used after extracting the resource template archive from github. Rename syscall does not support the moving file over different filesystems.

The resolution is not to call os.Rename(). It is changed to unzip the download archive to ``$HOME/.openvdc/registry`` directly. As part of  this change, unzip() function is improved that it extracts just the specified folder tree. The entier tree was extracted previsously.

Fixes #110.