### PR TITLE
Fix default conf

### DIFF
--- a/cmd/openvdc/cmd/root.go
+++ b/cmd/openvdc/cmd/root.go
@@ -12,8 +12,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "openvdc",

--- a/cmd/openvdc/main.go
+++ b/cmd/openvdc/main.go
@@ -14,7 +14,7 @@ const defaultTomlConfig = `
 [api]
 # endpoint = 127.0.0.1:5000
 [mesos]
-# address = 127.0.0.1:5050
+# master = 127.0.0.1:5050
 `
 
 func setupDefaultUserConfig(dir string) error {

--- a/cmd/openvdc/main.go
+++ b/cmd/openvdc/main.go
@@ -12,9 +12,9 @@ import (
 
 const defaultTomlConfig = `
 [api]
-# endpoint = 127.0.0.1:5000
+# endpoint = "127.0.0.1:5000"
 [mesos]
-# master = 127.0.0.1:5050
+# master = "127.0.0.1:5050"
 `
 
 func setupDefaultUserConfig(dir string) error {


### PR DESCRIPTION
Right now if the client doesn't find a config file it creates one with these default values:
```

[api]
# endpoint = 127.0.0.1:5000
[mesos]
# address = 127.0.0.1:5050

```
Both `cmd/root.go` and  `cmd/log.go` expects **mesos.master** though, not **mesos.address**,
so I changed this. I also added double quotes to the addresses so that they can be parsed
without giving an error.