### PR TITLE
Fix ci master copy

### DIFF
--- a/ci/acceptance-test/multibox/build.sh
+++ b/ci/acceptance-test/multibox/build.sh
@@ -69,6 +69,13 @@ if [[ "$REBUILD" == "true" ]]; then
             ) ; prev_cmd_failed
         done
     ) ; prev_cmd_failed
+
+    (
+        $starting_step "Create empty cache folder"
+        [ -d "${CACHE_DIR}/${BRANCH}" ]
+        $skip_step_if_already_done ; set -ex
+        mkdir -p "${CACHE_DIR}/${BRANCH}"
+    ) ; prev_cmd_failed
 else
     (   $starting_group "Set up cache for ${BRANCH} branch"
         [ -d "${CACHE_DIR}/${BRANCH}" ]

--- a/ci/acceptance-test/multibox/build.sh
+++ b/ci/acceptance-test/multibox/build.sh
@@ -70,15 +70,20 @@ if [[ "$REBUILD" == "true" ]]; then
         done
     ) ; prev_cmd_failed
 else
-    (
-        $starting_step "Create cache folder"
+    (   $starting_group "Set up cache for ${BRANCH} branch"
         [ -d "${CACHE_DIR}/${BRANCH}" ]
-        $skip_step_if_already_done ; set -ex
-        mkdir -p "${CACHE_DIR}/${BRANCH}"
+        $skip_group_if_unnecessary
+        (
+            $starting_step "Create cache folder"
+            false
+            $skip_step_if_already_done ; set -ex
+            mkdir -p "${CACHE_DIR}/${BRANCH}"
+        ) ; prev_cmd_failed
+
         (
           $starting_step "Copy cache from ${BASE_BRANCH} branch"
           [ ! -d "${CACHE_DIR}/${BASE_BRANCH}" ]
-          $skip_step_if_already_done
+          $skip_step_if_already_done ; set -ex
           rsync -av "${CACHE_DIR}/${BASE_BRANCH}/" "${CACHE_DIR}/${BRANCH}/"
         ) ; prev_cmd_failed
     ) ; prev_cmd_failed


### PR DESCRIPTION
* Fixed a bug where master cache couldn't be copied
* Fixed a bug where cache directory wasn't created if REBUILD=true on first run