### PR TITLE
Custom Log Fomatter for scheduler and executor

### DIFF
--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"sort"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
@@ -12,6 +14,7 @@ import (
 type LogFormatter struct {
 	DisableTimestamp  bool
 	DisableStacktrace bool
+	DisableFileLine   bool
 }
 
 func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -22,19 +25,22 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		b = &bytes.Buffer{}
 	}
 
+	if !f.DisableTimestamp {
+		b.WriteString(entry.Time.Format(logrus.DefaultTimestampFormat) + " ")
+	}
+
+	fmt.Fprintf(b, "[%s]", strings.ToUpper(entry.Level.String()))
+	if !f.DisableFileLine {
+		file, line := firstCaller()
+		fmt.Fprintf(b, " %s:%d", file, line)
+	}
+	fmt.Fprintf(b, " %s", entry.Message)
+
 	keys := make([]string, 0, len(entry.Data))
 	for k := range entry.Data {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-
-	if !f.DisableTimestamp {
-		b.WriteString(entry.Time.Format(logrus.DefaultTimestampFormat) + " ")
-	}
-
-	fmt.Fprintf(b, "[%s] %s",
-		entry.Level.String(),
-		entry.Message)
 	for _, k := range keys {
 		fmt.Fprintf(b, " %s=%s", k, entry.Data[k])
 	}
@@ -51,4 +57,62 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 	b.WriteString("\n")
 	return b.Bytes(), nil
+}
+
+const pkgLogrus = "github.com/Sirupsen/logrus"
+
+func firstCaller() (string, int) {
+	var pcs [32]uintptr
+	n := runtime.Callers(3, pcs[:])
+	for _, pc := range pcs[0:n] {
+		fn := runtime.FuncForPC(pc)
+		file, line := fn.FileLine(pc)
+		file = trimGOPATH(fn.Name(), file)
+		// Prefix match does not work for vendored pkgLogrus
+		if strings.Index(file, pkgLogrus) == -1 {
+			return file, line
+		}
+	}
+	return "", 0
+}
+
+// github.com/pkg/errors/stack.go
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
 }

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -44,7 +44,7 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(b, " %s=%s", k, entry.Data[k])
+		fmt.Fprintf(b, " %s=%v", k, entry.Data[k])
 	}
 	if !f.DisableStacktrace {
 		if err, exists := entry.Data[logrus.ErrorKey]; exists && err != nil {
@@ -53,7 +53,7 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 			}
 
 			if err, ok := err.(stackTracer); ok {
-				fmt.Fprintf(b, "\n%v", err)
+				fmt.Fprintf(b, "\n%+v", err.StackTrace())
 			}
 		}
 	}

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -63,7 +63,7 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 			}
 
 			if err, ok := err.(stackTracer); ok {
-				fmt.Fprintf(b, "\n%+v", err.StackTrace())
+				fmt.Fprintf(b, "\nErrorStackTrace:%+v", err.StackTrace())
 			}
 		}
 	} else {

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+)
+
+type LogFormatter struct {
+	DisableTimestamp  bool
+	DisableStacktrace bool
+}
+
+func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
+
+	keys := make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	if !f.DisableTimestamp {
+		b.WriteString(entry.Time.Format(logrus.DefaultTimestampFormat) + " ")
+	}
+
+	fmt.Fprintf(b, "[%s] %s",
+		entry.Level.String(),
+		entry.Message)
+	for _, k := range keys {
+		fmt.Fprintf(b, " %s=%s", k, entry.Data[k])
+	}
+	if !f.DisableStacktrace {
+		if err, exists := entry.Data[logrus.ErrorKey]; exists && err != nil {
+			type stackTracer interface {
+				StackTrace() errors.StackTrace
+			}
+
+			if err, ok := err.(stackTracer); ok {
+				fmt.Fprintf(b, "\n%v", err)
+			}
+		}
+	}
+	b.WriteString("\n")
+	return b.Bytes(), nil
+}

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const DefaultTimestampFormat = "2006-01-02 15:04:05"
+
 type LogFormatter struct {
 	DisableTimestamp  bool
 	DisableStacktrace bool
@@ -26,7 +28,7 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 
 	if !f.DisableTimestamp {
-		b.WriteString(entry.Time.Format(logrus.DefaultTimestampFormat) + " ")
+		b.WriteString(entry.Time.Format(DefaultTimestampFormat) + " ")
 	}
 
 	fmt.Fprintf(b, "[%s]", strings.ToUpper(entry.Level.String()))

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -46,7 +46,7 @@ func TestLogFomatter_StackTrace(t *testing.T) {
 
 	lines := strings.SplitN(buf.String(), "\n", 2)
 	ok, err := regexp.MatchString(
-		"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[ERROR\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test error=err1",
+		"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[ERROR\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test Error: err1",
 		lines[0])
 	if err != nil {
 		t.Error(err)

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -43,8 +43,7 @@ func TestLogFomatter_StackTrace(t *testing.T) {
 	err = errors.WithStack(err)
 
 	log.WithError(err).Error("test")
-
-	lines := strings.SplitN(buf.String(), "\n", 2)
+	lines := strings.SplitN(buf.String(), "\n", 3)
 	ok, err := regexp.MatchString(
 		"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[ERROR\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test Error: err1",
 		lines[0])
@@ -56,7 +55,7 @@ func TestLogFomatter_StackTrace(t *testing.T) {
 	}
 	ok, err = regexp.MatchString(
 		"^\\s*github\\.com/axsh/openvdc/cmd\\.TestLogFomatter_StackTrace",
-		lines[1])
+		lines[2])
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -16,7 +16,7 @@ func TestLogFomatter(t *testing.T) {
 
 	log.Info("test")
 	ok, err := regexp.Match(
-		"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2} \\[INFO\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test",
+		"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[INFO\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test",
 		buf.Bytes())
 	if err != nil {
 		t.Error(err)

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -2,17 +2,26 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"regexp"
 	"testing"
 
+	"strings"
+
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 )
+
+func newLogger(w io.Writer) *logrus.Logger {
+	log := logrus.New()
+	log.Formatter = new(LogFormatter)
+	log.Out = w
+	return log
+}
 
 func TestLogFomatter(t *testing.T) {
 	buf := new(bytes.Buffer)
-	log := logrus.New()
-	log.Formatter = new(LogFormatter)
-	log.Out = buf
+	log := newLogger(buf)
 
 	log.Info("test")
 	ok, err := regexp.Match(
@@ -23,5 +32,35 @@ func TestLogFomatter(t *testing.T) {
 	}
 	if !ok {
 		t.Error("Does not match: ", buf.String())
+	}
+}
+
+func TestLogFomatter_StackTrace(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log := newLogger(buf)
+
+	err := errors.New("err1")
+	err = errors.WithStack(err)
+
+	log.WithError(err).Error("test")
+
+	lines := strings.SplitN(buf.String(), "\n", 2)
+	ok, err := regexp.MatchString(
+		"^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[ERROR\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test error=err1",
+		lines[0])
+	if err != nil {
+		t.Error(err)
+	}
+	if !ok {
+		t.Error("Does not match log line: ", lines[0])
+	}
+	ok, err = regexp.MatchString(
+		"^\\s*github\\.com/axsh/openvdc/cmd\\.TestLogFomatter_StackTrace",
+		lines[1])
+	if err != nil {
+		t.Error(err)
+	}
+	if !ok {
+		t.Error("Does not match stack trace line: ", lines[1])
 	}
 }

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestLogFomatter(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log := logrus.New()
+	log.Formatter = new(LogFormatter)
+	log.Out = buf
+
+	log.Info("test")
+	ok, err := regexp.Match(
+		"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2} \\[INFO\\] github.com/axsh/openvdc/cmd/formatter_test.go:\\d+ test",
+		buf.Bytes())
+	if err != nil {
+		t.Error(err)
+	}
+	if !ok {
+		t.Error("Does not match: ", buf.String())
+	}
+}

--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -425,6 +425,7 @@ func execute(cmd *cobra.Command, args []string) {
 }
 
 func main() {
+	logrus.SetFormatter(&cmd.LogFormatter{})
 	rootCmd.AddCommand(cmd.VersionCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/openvdc-scheduler/main.go
+++ b/cmd/openvdc-scheduler/main.go
@@ -106,6 +106,7 @@ func execute(cmd *cobra.Command, args []string) {
 
 func main() {
 	flag.CommandLine.Parse([]string{})
+	log.SetFormatter(&cmd.LogFormatter{})
 	rootCmd.AddCommand(cmd.VersionCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
logrus default formatter is poor output.  so we create custom log formatter that supports:

- Source path and line where ``logrus.*`` method is called.
- Show stack trace if error object is wrapped with ``github.com/pkg/errors``

```
2017-02-15 13:50:02 [INFO] github.com/axsh/openvdc/scheduler/mesos.go:90 Skip offers since no allocation requests.
```

```
2017-02-15 19:55:54 [ERROR] github.com/axsh/openvdc/cmd/formatter_test.go:47 test Error: err1
ErrorStackTrace:
github.com/axsh/openvdc/cmd.TestLogFomatter_StackTrace
	/Users/unakatsuo/go/src/github.com/axsh/openvdc/cmd/formatter_test.go:44
testing.tRunner
	/usr/local/go/src/testing/testing.go:610
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2086
```