### PR TITLE
Update for vscode-proto3 plugin v0.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,12 @@
     "vendor/**": true,
     "vendor/vendor.json": false
   },
+  "protoc": {
+    "options": [
+      "--proto_path=${workspaceRoot}/proto",
+      "--proto_path=${env.GOPATH}/src"
+    ]
+  },
   "json.schemas": [
     {
       "fileMatch": [


### PR DESCRIPTION
It allows vscode to run syntax checker for .proto files with proper protoc parameters.