### PR TITLE
Chown fix in acceptance test docker script

### DIFF
--- a/ci/acceptance-test/build_and_run_in_docker.sh
+++ b/ci/acceptance-test/build_and_run_in_docker.sh
@@ -30,6 +30,11 @@ function cleanup() {
   else
     echo "LEAVE_CONTAINER was set and not 0. Skip container cleanup."
   fi
+
+  # Give the newly created cache to this user instead of root so we can clean it up
+  # later without needing sudo
+  local user=$(/usr/bin/id -run)
+  sudo chown -R $user:$user "${CACHE_DIR}"/"${BRANCH}"
 }
 trap "cleanup" EXIT
 
@@ -39,5 +44,3 @@ sudo docker build -t "${repo_and_tag}" --build-arg BRANCH="${BRANCH}" \
                                   "${whereami}"
 
 sudo docker run --privileged -v "${DATA_DIR}":/data "${repo_and_tag}"
-
-sudo chown -R jenkins:jenkins "${CACHE_DIR}"/"${BRANCH}"


### PR DESCRIPTION
The acceptance test needs to make jenkins the owner of its cache images so the garbage collection job can delete them later without using sudo.

This was done in the main script after `docker run` which caused it to not be executed after if the tests (and thus the `docker run` command) failed. I moved it to the cleanup function so it is always executed.

While I was at it I also changed it so it uses whatever the current user is instead of jenkins.