### PR TITLE
Upgrade to golang-1.7

### DIFF
--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -1,9 +1,11 @@
 FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
+RUN yum install -y yum-utils
+RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
-RUN yum install -y yum-utils go git createrepo
+RUN yum install -y go git createrepo
 
 
 ENV GOPATH=/var/tmp/go PATH=$PATH:$GOPATH/bin

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y yum-utils
 RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
-RUN yum install -y go git createrepo
+RUN yum install -y golang git createrepo
 
 
 ENV GOPATH=/var/tmp/go PATH=$PATH:$GOPATH/bin

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -6,7 +6,7 @@ RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 
-RUN yum install -y git go
+RUN yum install -y git golang
 ENV GOPATH=/var/tmp/go
 ENV PATH=$PATH:$GOPATH/bin
 RUN mkdir $GOPATH

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
+RUN yum install -y yum-utils
+RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -14,7 +14,7 @@ License: LGPLv3
 BuildArch: x86_64
 
 BuildRequires: rpmdevtools lxc-devel git
-BuildRequires: golang >= 1.6
+BuildRequires: golang >= 1.7
 
 Requires: mesosphere-zookeeper mesos
 %{systemd_requires}


### PR DESCRIPTION
go1.6 is outdate since go1.8 has been released Feb/2017. CentOS 7.3 bundles golang-1.6 rpms in main repo but I found go 1.7 rpms in ``centosplus`` repo.

http://mirror.centos.org/centos/7.3.1611/centosplus/x86_64/Packages/

https://wiki.centos.org/AdditionalResources/Repositories/CentOSPlus