### PR TITLE
Use fixed port number for executor sshd

### DIFF
--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -3,12 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/axsh/openvdc/api/executor"
@@ -415,8 +412,7 @@ var DefaultConfPath string
 var zkAddr backend.ZkEndpoint
 
 const defaultExecutorAPIPort = "19372"
-
-var defaultSSHPortRange = [2]int{29876, 39876}
+const defaultSSHPort = "29876"
 
 func startExecutorAPIServer(ctx context.Context, listener net.Listener) *executor.ExecutorAPIServer {
 	s := executor.NewExecutorAPIServer(&zkAddr, ctx)
@@ -427,9 +423,9 @@ func startExecutorAPIServer(ctx context.Context, listener net.Listener) *executo
 func init() {
 	viper.SetDefault("hypervisor.driver", "null")
 	viper.SetDefault("zookeeper.endpoint", "zk://localhost/openvdc")
-	viper.SetDefault("executor-api.listen", "0.0.0.0:19372")
+	viper.SetDefault("executor-api.listen", "0.0.0.0:"+defaultExecutorAPIPort)
 	viper.SetDefault("executor-api.advertise-ip", "")
-	viper.SetDefault("console.ssh.listen", "")
+	viper.SetDefault("console.ssh.listen", "0.0.0.0:"+defaultSSHPort)
 	viper.SetDefault("console.ssh.advertise-ip", "")
 
 	cobra.OnInitialize(initConfig)
@@ -439,11 +435,6 @@ func init() {
 	viper.BindPFlag("hypervisor.driver", pfs.Lookup("hypervisor"))
 	pfs.String("zk", viper.GetString("zookeeper.endpoint"), "Zookeeper address")
 	viper.BindPFlag("zookeeper.endpoint", pfs.Lookup("zk"))
-}
-
-func randomPort(min, max int) int {
-	rand.Seed(time.Now().Unix())
-	return rand.Intn(max-min) + min
 }
 
 func initConfig() {
@@ -511,20 +502,9 @@ func execute(cmd *cobra.Command, args []string) {
 		log.Infof("Exposed Executor gRPC API on %s", exposedExecutorAPIAddr)
 	}
 
-	sshPort := strconv.Itoa(randomPort(defaultSSHPortRange[0], defaultSSHPortRange[1]))
-	sshListenIP := "0.0.0.0"
-	if viper.GetString("console.ssh.listen") != "" {
-		var port string
-		sshListenIP, port, err = net.SplitHostPort(viper.GetString("console.ssh.listen"))
-		if err != nil {
-			log.WithError(err).Fatal("Failed to parse host:port: ", viper.GetString("console.ssh.listen"))
-		}
-		sshPort = port
-	}
-	sshListenAddr := net.JoinHostPort(sshListenIP, sshPort)
-	sshListener, err := net.Listen("tcp", sshListenAddr)
+	sshListener, err := net.Listen("tcp", viper.GetString("console.ssh.listen"))
 	if err != nil {
-		log.WithError(err).Fatalf("Failed to listen SSH on %s", sshListenAddr)
+		log.WithError(err).Fatalf("Failed to listen SSH on %s", sshListener.Addr().String())
 	}
 	defer sshListener.Close()
 
@@ -533,10 +513,14 @@ func execute(cmd *cobra.Command, args []string) {
 		log.WithError(err).Fatal("Failed to setup SSH Server")
 	}
 	go sshd.Run(sshListener)
-	log.Infof("Listening SSH on %s", sshListenAddr)
+	log.Infof("Listening SSH on %s", sshListener.Addr().String())
 	exposedSSHAddr := sshListener.Addr().String()
 	if viper.GetString("console.ssh.advertise-ip") != "" {
-		exposedSSHAddr = net.JoinHostPort(viper.GetString("console.ssh.advertise-ip"), sshPort)
+		_, port, err := net.SplitHostPort(exposedSSHAddr)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to parse host:port: ", exposedSSHAddr)
+		}
+		exposedSSHAddr = net.JoinHostPort(viper.GetString("console.ssh.advertise-ip"), port)
 		log.Infof("Exposed SSH on %s", exposedSSHAddr)
 	}
 


### PR DESCRIPTION
The listen port number for the embedded sshd was chosen randomly by default. That decision just made the code for initialization complex. So it listens TCP ``29876`` port by default. Users still can apply arbitrary listen port from ``console.ssh.listen`` configuration parameter.