### PR TITLE
Fix #146

### DIFF
--- a/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/build.sh
+++ b/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/build.sh
@@ -16,6 +16,7 @@ IND_STEPS=(
     "hosts"
     "disable-firewalld"
     "epel"
+    "bridge-utils"
     "lxc"
     "mesosphere"
     "mesos"

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-bridge-utils/install.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-bridge-utils/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+install_yum_package "bridge-utils"

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -107,7 +107,6 @@ Null driver configuration package for OpenVDC executor.
 
 %files executor-null
 %config(noreplace) /etc/openvdc/executor.toml
-%config(noreplace) /etc/openvdc/scripts/*
 
 %package executor-lxc
 Summary: OpenVDC executor (LXC driver)
@@ -122,6 +121,8 @@ LXC driver configuration package for OpenVDC executor.
 
 %files executor-lxc
 %config(noreplace) /etc/openvdc/executor.toml
+%dir /etc/openvdc/scripts
+%config(noreplace) /etc/openvdc/scripts/*
 
 %post executor-lxc
 if [ -d /etc/mesos-slave ]; then

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -114,7 +114,7 @@ Summary: OpenVDC executor (LXC driver)
 Requires: openvdc-executor
 Requires: lxc
 # lxc-templates does not resolve its sub dependencies
-Requires: lxc-templates wget gpg sed awk coreutils rsync debootstrap dropbear
+Requires: lxc-templates wget gpg sed gawk coreutils rsync debootstrap dropbear
 Requires: bridge-utils
 
 %description executor-lxc

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -113,7 +113,8 @@ Null driver configuration package for OpenVDC executor.
 Summary: OpenVDC executor (LXC driver)
 Requires: openvdc-executor
 Requires: lxc
-Requires: lxc-templates
+# lxc-templates does not resolve its sub dependencies
+Requires: lxc-templates wget gpg sed awk coreutils rsync debootstrap dropbear
 Requires: bridge-utils
 
 %description executor-lxc


### PR DESCRIPTION
#146 generates broken rpm for executor-lxc package. This is amendment for the PR.

- executor crashes at lxc.CreateInstance(). The root cause was ``/usr/share/lxc-download`` template script could not find ``wget``
- Miss to bundle ``/etc/openvdc/scripts/*``


```
2017-03-30 10:14:07 [ERROR] openvdc-executor/main.go:128 Failed CreateInstance Error: Failed to parse script template: /etc/openvdc/scripts/linux-bridge
-up.sh.tmpl: open /etc/openvdc/scripts/linux-bridge-up.sh.tmpl: no such file or directory context=vdc-executor hypervisor=lxc instance_id=i-0000000000 s
tate=STARTING
ErrorStackTrace:
github.com/axsh/openvdc/hypervisor/lxc.(*LXCHypervisorDriver).renderUpDownScript
        /var/tmp/go/src/github.com/axsh/openvdc/hypervisor/lxc/lxc.go:216
github.com/axsh/openvdc/hypervisor/lxc.(*LXCHypervisorDriver).CreateInstance
        /var/tmp/go/src/github.com/axsh/openvdc/hypervisor/lxc/lxc.go:289
main.(*VDCExecutor).bootInstance
        /var/tmp/go/src/github.com/axsh/openvdc/cmd/openvdc-executor/main.go:125
main.(*VDCExecutor).LaunchTask
        /var/tmp/go/src/github.com/axsh/openvdc/cmd/openvdc-executor/main.go:71
github.com/axsh/openvdc/vendor/github.com/mesos/mesos-go/executor.(*MesosExecutorDriver).runTask.func1
        /var/tmp/go/src/github.com/axsh/openvdc/vendor/github.com/mesos/mesos-go/executor/executor.go:418
github.com/axsh/openvdc/vendor/github.com/mesos/mesos-go/executor.NewMesosExecutorDriver.func2.1
        /var/tmp/go/src/github.com/axsh/openvdc/vendor/github.com/mesos/mesos-go/executor/executor.go:112
runtime.goexit
        /usr/lib/golang/src/runtime/asm_amd64.s:2086
````