### PR TITLE
Revert "ci/tests: WaitInstance() -> openvdc wait"

### DIFF
--- a/ci/citest/acceptance-test/tests/cmd_console_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_console_test.go
@@ -5,14 +5,15 @@ package tests
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCmdConsole_ShowOption(t *testing.T) {
 	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/lxc")
 	instance_id := strings.TrimSpace(stdout.String())
 
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "RUNNING")
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "console", instance_id, "--show")
 	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "TERMINATED")
+	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)
 }

--- a/ci/citest/acceptance-test/tests/cmd_log_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_log_test.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOpenVDCLog(t *testing.T) {
@@ -12,6 +13,6 @@ func TestOpenVDCLog(t *testing.T) {
 	instance_id := strings.TrimSpace(stdout.String())
 	defer RunCmd("openvdc", "destroy", instance_id)
 
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "RUNNING")
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "log", instance_id)
 }

--- a/ci/citest/acceptance-test/tests/cmd_reboot_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_reboot_test.go
@@ -13,12 +13,12 @@ func TestCmdReboot(t *testing.T) {
 	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/lxc")
 	instance_id := strings.TrimSpace(stdout.String())
 
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "RUNNING")
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 
 	testCmdReboot_Centos7(t, instance_id)
 
-	RunCmdAndReportFail(t, "openvdc", "destroy", instance_id)
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "TERMINATED")
+	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
+	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)
 }
 
 func testCmdReboot_Ubuntu14(t *testing.T, instance_id string) {

--- a/ci/citest/acceptance-test/tests/cmd_run_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_run_test.go
@@ -5,16 +5,17 @@ package tests
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCmdRun_NullTemplate(t *testing.T) {
 	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/null")
 	instance_id := strings.TrimSpace(stdout.String())
 
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "RUNNING")
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 
 	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
-	RunCmdAndReportFail(t, "openvdc", "wait", instance_id, "TERMINATED")
+	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)
 }
 
 func TestCmdRun_NoneTemplate(t *testing.T) {


### PR DESCRIPTION
CI tests on master branch stales due to #139. The change needs more work. So revert the acceptance test code where wait for instance state change.