### PR TITLE
Fix appveyor build with zookeeper tarball

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,9 @@ install:
   - ps: New-Item C:\ZooKeeper -type directory
   - powershell -ExecutionPolicy Bypass .\ci\appveyor\install-zk.ps1 C:\ZooKeeper
   - ps: $ZkProcess = Start-Process -FilePath "C:\ZooKeeper\bin\zkServer.cmd" -PassThru -NoNewWindow
+  - dir C:\ZooKeeper
   - ps: $ZkProcess | fl
+  - ps: if ( $ZkProcess.HasExited -eq $True ) { Write-Error "Failed to start zookeeper"; exit 1; }
 
 build_script:
   - set PATH=C:\gopath\bin;%PATH%

--- a/ci/appveyor/install-zk.ps1
+++ b/ci/appveyor/install-zk.ps1
@@ -2,10 +2,10 @@ $ErrorActionPreference = "Stop"
 
 Set-Location -Path $Args[0]
 
-Invoke-WebRequest -Uri http://www-us.apache.org/dist/zookeeper/stable/zookeeper-3.4.9.tar.gz -OutFile zookeeper.tar.gz
+Invoke-WebRequest -Uri http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -OutFile zookeeper.tar.gz
 7z -y e "zookeeper.tar.gz"
 7z -y x "zookeeper.tar"
-Move-Item zookeeper-3.4.9\* .
+Move-Item zookeeper-3.4.6\* .
 New-Item data -type directory
 Move-Item conf\zoo_sample.cfg conf\zoo.cfg
 "dataDir=C:\ZooKeeper\data" | Out-File conf\zoo.cfg -Encoding ASCII -Append

--- a/ci/appveyor/install-zk.ps1
+++ b/ci/appveyor/install-zk.ps1
@@ -2,10 +2,10 @@ $ErrorActionPreference = "Stop"
 
 Set-Location -Path $Args[0]
 
-Invoke-WebRequest -Uri http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz -OutFile zookeeper.tar.gz
+Invoke-WebRequest -Uri http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz -OutFile zookeeper.tar.gz
 7z -y e "zookeeper.tar.gz"
 7z -y x "zookeeper.tar"
-Move-Item zookeeper-3.4.6\* .
+Move-Item zookeeper-3.4.9\* .
 New-Item data -type directory
 Move-Item conf\zoo_sample.cfg conf\zoo.cfg
 "dataDir=C:\ZooKeeper\data" | Out-File conf\zoo.cfg -Encoding ASCII -Append


### PR DESCRIPTION
Build on appveyor has been failing due to missing URL for zookeeper tarball. They seem to release new version as stable and the previous version 3.4.9 was moved.

```
Invoke-WebRequest : Not Found
The requested URL /dist/zookeeper/stable/zookeeper-3.4.9.tar.gz was not found 
on this server.
At C:\gopath\src\github.com\axsh\openvdc\ci\appveyor\install-zk.ps1:5 char:1
+ Invoke-WebRequest -Uri http://www-us.apache.org/dist/zookeeper/stable ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

~~On Linux, we are using 3.4.6 so that Windows build should also install same version.~~

```
mesosphere-zookeeper.x86_64 0:3.4.6-0.1.20141204175332.centos7                
```

The version was difficult to run on Windows. I backed to install 3.4.9.