### PR TITLE
Simplify zk Update()

### DIFF
--- a/model/backend/zk.go
+++ b/model/backend/zk.go
@@ -197,17 +197,8 @@ func (z *Zk) Update(key string, value []byte) error {
 	if !z.isConnected() {
 		return ErrConnectionNotReady
 	}
-	var err error
 	absKey, _ := z.canonKey(key)
-
-	ok, stat, err := z.connection().Exists(absKey)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return ErrUnknownKey(absKey)
-	}
-	if _, err := z.connection().Set(absKey, value, stat.Version); err != nil {
+	if _, err := z.connection().Set(absKey, value, versionAny); err != nil {
 		return errors.Wrapf(err, "Failed zk.Set %s", absKey)
 	}
 	return nil


### PR DESCRIPTION
``go-zookeeper``'s ``Conn.Set()`` requires the version ID to update the item. ``-1`` allows to update the key without specifying valid version ID.