### PR TITLE
Stop DHCPDISCOVER from .100.14 (executor-lxc)

### DIFF
--- a/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/guestroot/etc/sysconfig/network-scripts/ifcfg-eth1
+++ b/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/guestroot/etc/sysconfig/network-scripts/ifcfg-eth1
@@ -2,3 +2,4 @@ DEVICE="eth1"
 ONBOOT="yes"
 BRIDGE=br0
 NM_CONTROLLED=no
+BOOTPROTO=none

--- a/ci/citest/acceptance-test/multibox/ind-steps/common.source
+++ b/ci/citest/acceptance-test/multibox/ind-steps/common.source
@@ -7,9 +7,9 @@ function create_bridge() {
 
   (
     $starting_step "Create bridge ${name}"
-    brctl show | grep -q "${name}"
+    ip link show dev "${name}" > /dev/null
     $skip_step_if_already_done ; set -xe
-    sudo brctl addbr "${name}"
+    sudo ip link add name "${name}" type bridge
     sudo ip link set "${name}" up
 
     if [[ -n "${ip_addr}" ]]; then
@@ -128,12 +128,12 @@ function destroy_bridge() {
 
   (
     $starting_step "Destroy bridge ${name}"
-    brctl show | grep -q "${name}"
+    ip link show dev "${name}" > /dev/null
     [ "$?" != "0" ]
     $skip_step_if_already_done ; set -x +e
     # Ignore errors for complete teardown.
-    sudo ip link set "${1}" down
-    sudo brctl delbr "${1}"
+    sudo ip link set "${name}" down
+    sudo ip link delete dev "${name}"
   ) # ; prev_cmd_failed ### TODO: bashstep missing feature (axsh/openvdc#77)
 }
 

--- a/ci/citest/acceptance-test/tests/02_start_and_terminate_lxc_instance_test.go
+++ b/ci/citest/acceptance-test/tests/02_start_and_terminate_lxc_instance_test.go
@@ -33,7 +33,7 @@ func TestLXCInstance_NICx2(t *testing.T) {
 	RunCmdAndReportFail(t, "openvdc", "show", instance_id)
 	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, "sudo lxc-info -n "+instance_id, 10, 5)
-	stdout, _, err := RunSsh(executor_lxc_ip, fmt.Sprintf("bridge link show dev %s", instance_id+"_00"))
+	stdout, _, err := RunSsh(executor_lxc_ip, fmt.Sprintf("/usr/sbin/bridge link show dev %s", instance_id+"_00"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -44,7 +44,7 @@ func TestLXCInstance_NICx2(t *testing.T) {
 			t.Log("bridge link show dev "+instance_id+"_00: ", stdout.String())
 		}
 	}
-	stdout, _, err = RunSsh(executor_lxc_ip, fmt.Sprintf("bridge link show dev %s", instance_id+"_01"))
+	stdout, _, err = RunSsh(executor_lxc_ip, fmt.Sprintf("/usr/sbin/bridge link show dev %s", instance_id+"_01"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/ci/citest/acceptance-test/tests/02_start_and_terminate_lxc_instance_test.go
+++ b/ci/citest/acceptance-test/tests/02_start_and_terminate_lxc_instance_test.go
@@ -3,8 +3,7 @@
 package tests
 
 import (
-	"bufio"
-	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -26,46 +25,35 @@ func TestLXCInstance(t *testing.T) {
 	RunSshWithTimeoutAndExpectFail(t, executor_lxc_ip, "sudo lxc-info -n "+instance_id, 10, 5)
 }
 
-
 func TestLXCInstance_NICx2(t *testing.T) {
 	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/lxc",
-	`{"interfaces":[{"type":"veth", "bridge":"linux"}, {"type":"veth", "bridge":"linux"}]}`)
+		`{"interfaces":[{"type":"veth", "bridge":"linux"}, {"type":"veth", "bridge":"linux"}]}`)
 	instance_id := strings.TrimSpace(stdout.String())
 
 	RunCmdAndReportFail(t, "openvdc", "show", instance_id)
 	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, "sudo lxc-info -n "+instance_id, 10, 5)
-	stdout, _, err := RunSsh(executor_lxc_ip, "/usr/sbin/brctl show br0")
+	stdout, _, err := RunSsh(executor_lxc_ip, fmt.Sprintf("bridge link show dev %s", instance_id+"_00"))
 	if err != nil {
 		t.Error(err)
 	}
-	/* Expected Output
-	bridge name bridge id         STP  enabled interfaces
-	br0         8000.fe0e49305657	no		       i-0000000001_00
-	                                           i-0000000001_01
-	*/
-	lines := bufio.NewScanner(stdout)
-	lines.Scan() // Skip "brctl show" header
-	lines.Scan()
-	line_if00 := bufio.NewScanner(bytes.NewReader(lines.Bytes()))
-	line_if00.Split(bufio.ScanWords)
-	// "br0          8000.080027a02faf       no              i-00000000_00"
-	line_if00.Scan()
-	line_if00.Scan()
-	line_if00.Scan()
-	line_if00.Scan()
-	t.Log(line_if00.Text())
-	if line_if00.Text() != instance_id + "_00" {
+	if stdout.Len() == 0 {
 		t.Errorf("Interface %s is not attached", instance_id+"_00")
+	} else {
+		if testing.Verbose() {
+			t.Log("bridge link show dev "+instance_id+"_00: ", stdout.String())
+		}
 	}
-	lines.Scan()
-	line_if01 := bufio.NewScanner(bytes.NewReader(lines.Bytes()))
-	line_if01.Split(bufio.ScanWords)
-	// "                                    i-00000000_01"
-	line_if01.Scan()
-	t.Log(line_if01.Text())
-	if line_if01.Text() != instance_id + "_01" {
+	stdout, _, err = RunSsh(executor_lxc_ip, fmt.Sprintf("bridge link show dev %s", instance_id+"_01"))
+	if err != nil {
+		t.Error(err)
+	}
+	if stdout.Len() == 0 {
 		t.Errorf("Interface %s is not attached", instance_id+"_01")
+	} else {
+		if testing.Verbose() {
+			t.Log("bridge link show dev "+instance_id+"_01: ", stdout.String())
+		}
 	}
 
 	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)

--- a/pkg/conf/scripts/linux-bridge-down.sh.tmpl
+++ b/pkg/conf/scripts/linux-bridge-down.sh.tmpl
@@ -10,4 +10,4 @@ ACTION=$3  # up/down
 IFTYPE=$4  # veth,macvlan,etc...
 IFNAME=$5
 
-brctl delif {{.BridgeName}} "${IFNAME}"
+ip link set dev "${IFNAME}" nomaster

--- a/pkg/conf/scripts/linux-bridge-up.sh.tmpl
+++ b/pkg/conf/scripts/linux-bridge-up.sh.tmpl
@@ -10,4 +10,4 @@ ACTION=$3  # up/down
 IFTYPE=$4  # veth,macvlan,etc...
 IFNAME=$5
 
-brctl addif {{.BridgeName}} "${IFNAME}"
+ip link set dev "${IFNAME}" master {{.BridgeName}}

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -114,7 +114,7 @@ Requires: openvdc-executor
 Requires: lxc
 # lxc-templates does not resolve its sub dependencies
 Requires: lxc-templates wget gpg sed gawk coreutils rsync debootstrap dropbear
-Requires: bridge-utils
+Requires: iproute
 
 %description executor-lxc
 LXC driver configuration package for OpenVDC executor.


### PR DESCRIPTION
https://ci.openvdc.org/blue/rest/organizations/jenkins/pipelines/citest/branches/attrib-node-groups/runs/6/nodes/36/log/

```
May 16 18:23:01 executor-lxc dhclient[11160]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 12 (xid=0x6390338e)
May 16 18:23:13 executor-lxc dhclient[11160]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 13 (xid=0x6390338e)
May 16 18:23:17 executor-lxc NetworkManager[410]: <warn>  (eth1): DHCPv4 request timed out.
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): DHCPv4 state changed unknown -> timeout
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): canceled DHCP transaction, DHCP client pid 11160
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): DHCPv4 state changed timeout -> done
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: ip-config -> failed (reason 'ip-config-unavailable') [70 120 5]
May 16 18:23:17 executor-lxc NetworkManager[410]: <warn>  (eth1): Activation: failed for connection 'Wired connection 1'
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: failed -> disconnected (reason 'none') [120 30 0]
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  Auto-activating connection 'Wired connection 1'.
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): Activation: starting connection 'Wired connection 1' (cd9dfa6f-3ae4-431a-be9f-f7b8ce1b0958)
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: disconnected -> prepare (reason 'none') [30 40 0]
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: prepare -> config (reason 'none') [40 50 0]
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: config -> ip-config (reason 'none') [50 70 0]
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  Activation (eth1) Beginning DHCPv4 transaction (timeout in 45 seconds)
May 16 18:23:17 executor-lxc NetworkManager[410]: <info>  dhclient started with pid 11176
May 16 18:23:17 executor-lxc dhclient[11176]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 8 (xid=0x7ee9595f)
May 16 18:23:25 executor-lxc dhclient[11176]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 15 (xid=0x7ee9595f)
May 16 18:23:40 executor-lxc dhclient[11176]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 8 (xid=0x7ee9595f)
May 16 18:23:48 executor-lxc dhclient[11176]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 15 (xid=0x7ee9595f)
May 16 18:23:49 executor-lxc mesos-slave[806]: I0516 18:23:49.710258   998 slave.cpp:5267] Current disk usage 3.84%. Max allowed age: 6.031525879806099days
May 16 18:24:02 executor-lxc NetworkManager[410]: <warn>  (eth1): DHCPv4 request timed out.
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): DHCPv4 state changed unknown -> timeout
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): canceled DHCP transaction, DHCP client pid 11176
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): DHCPv4 state changed timeout -> done
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: ip-config -> failed (reason 'ip-config-unavailable') [70 120 5]
May 16 18:24:02 executor-lxc NetworkManager[410]: <warn>  (eth1): Activation: failed for connection 'Wired connection 1'
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: failed -> disconnected (reason 'none') [120 30 0]
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  Auto-activating connection 'Wired connection 1'.
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): Activation: starting connection 'Wired connection 1' (cd9dfa6f-3ae4-431a-be9f-f7b8ce1b0958)
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: disconnected -> prepare (reason 'none') [30 40 0]
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: prepare -> config (reason 'none') [40 50 0]
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  (eth1): device state change: config -> ip-config (reason 'none') [50 70 0]
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  Activation (eth1) Beginning DHCPv4 transaction (timeout in 45 seconds)
May 16 18:24:02 executor-lxc NetworkManager[410]: <info>  dhclient started with pid 11180
May 16 18:24:02 executor-lxc dhclient[11180]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 6 (xid=0x5ee79c9c)
May 16 18:24:08 executor-lxc dhclient[11180]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 16 (xid=0x5ee79c9c)
May 16 18:24:24 executor-lxc dhclient[11180]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 17 (xid=0x5ee79c9c)
May 16 18:24:41 executor-lxc dhclient[11180]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 9 (xid=0x5ee79c9c)
```