### PR TITLE
Added executor-lxc to meta package

### DIFF
--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -21,6 +21,7 @@ Requires: bridge-utils
 %{systemd_requires}
 Requires: openvdc-cli
 Requires: openvdc-executor
+Requires: openvdc-executor-lxc
 Requires: openvdc-scheduler
 
 ## This will not work with rpm v. 4.11 (which is what the jenkins vm has!)


### PR DESCRIPTION
#169 

Meta package didn't include executor-lxc, so the scripts didn't get installed.