### PR TITLE
Fix for failing local_imate_test.go occasinally.

### DIFF
--- a/ci/citest/acceptance-test/tests/local_image_test.go
+++ b/ci/citest/acceptance-test/tests/local_image_test.go
@@ -11,7 +11,7 @@ import (
 func TestLocalImage(t *testing.T) {
 
 	// Use custom lxc-template.
-	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/lxc", `{"lxc_template":{"template":"openvdc"}}`)
+	stdout, _ := RunCmdAndReportFail(t, "openvdc", "run", "centos/7/lxc", `{"lxc_template":{"template":"openvdc"}, "node_groups":["linuxbr"]}`)
 	instance_id := strings.TrimSpace(stdout.String())
 
 	_, _ = RunCmdAndReportFail(t, "openvdc", "show", instance_id)


### PR DESCRIPTION
``ci/citest/tests/local_image_test.go`` runs the test instance without ``node_groups: ["linuxbr"]`` attribute. so that the later ssh checking is failing sometime.

https://github.com/axsh/openvdc/pull/168#issuecomment-305739019

