### PR TITLE
Refactor download images to bashsteps

### DIFF
--- a/ci/citest/acceptance-test/multibox/10.0.100.12-vdc-scheduler/build.sh
+++ b/ci/citest/acceptance-test/multibox/10.0.100.12-vdc-scheduler/build.sh
@@ -19,6 +19,7 @@ IND_STEPS=(
     "apache"
     "mesosphere-repo"
     "zookeeper"
+    "vdc-images"
 )
 
 build "${IND_STEPS[@]}"
@@ -26,77 +27,8 @@ build "${IND_STEPS[@]}"
 # This is not part of the ind-steps because we don't want OpenVDC installed in
 # the cached images. We want a clean cache without OpenVDC so we can install a
 # different version to test every the CI runs.
+
 install_openvdc_yum_repo
 install_yum_package_over_ssh "openvdc-scheduler"
 enable_service_over_ssh "openvdc-scheduler"
 enable_service_over_ssh "httpd"
-
-function download_container_image () {
-        local img="${1}"
-        (
-		printf "\nPreparing to download image: $img \n"
-                meta="meta.tar.xz"
-                rootfs="rootfs.tar.xz"
-
-                imgHost="https://uk.images.linuxcontainers.org"
-                imgHostIndex="https://uk.images.linuxcontainers.org/meta/1.0/index-system"
-                imgIndex=$(curl -s "$imgHostIndex")
-
-                for item in ${imgIndex//\\n/}
-                do
-                	if [[ $item =~ $img ]]
-               	 	then
-				IFS=';' read -a parts <<< "$item"
-
-				imgRemoteDir=${parts[-1]}
-				imgHost+=$imgRemoteDir
-
-				IFS=';' eval 'folders=($item)'
-				imgSpec="${folders[0]}/${folders[1]}/${folders[2]}"
-
-				if [ ! -d "$IMG_DIR/$imgSpec" ]; then
-					mkdir -p "$IMG_DIR/$imgSpec"
-				else
-					printf "\nDirectory already exists: $IMG_DIR/$imgSpec\n"
-				fi
-
-				if [ ! -f "$IMG_DIR/$imgSpec/$meta" ]; then
-					printf "\nDownloading file:\n$imgHost$meta\n"
-					curl -o "$IMG_DIR/$imgSpec/$meta" "$imgHost/$meta"
-				else
-					printf "\nFile already exists, skipping download: $IMG_DIR/$imgSpec/$meta\n"
-				fi
-
-				if [ ! -f "$IMG_DIR/$imgSpec/$rootfs" ]; then
-					printf "\nDownloading file:\n$imgHost$rootfs\n"
-					curl -o "$IMG_DIR/$imgSpec/$rootfs" "$imgHost/$rootfs"
-				else
-					printf "\nFile already exists, skipping download: $IMG_DIR/$imgSpec/$rootfs\n"
-				fi
-                	fi
-               	done
-
-		printf "\nCreating folder ${IP_ADDR}:/var/www/html/images/$imgSpec\n"
-		ssh -o StrictHostKeyChecking=no -i "${ENV_ROOTDIR}/10.0.100.12-vdc-scheduler/sshkey" "root@${IP_ADDR}" "mkdir -p /var/www/html/images/$imgSpec"
-
-		if [ -f "$IMG_DIR/$imgSpec/$meta" ]; then
-			printf "\nCopying file: $IMG_DIR/$imgSpec/$meta\n"
-			scp -o StrictHostKeyChecking=no -i "${ENV_ROOTDIR}/10.0.100.12-vdc-scheduler/sshkey" "$IMG_DIR/$imgSpec/$meta" "root@${IP_ADDR}:/var/www/html/images/$imgSpec"
-		else
-			printf "\nFile not found: $IMG_DIR/$imgSpec/$meta\n"
-		fi
-
-		if [ -f "$IMG_DIR/$imgSpec/$rootfs" ]; then
-                        printf "\nCopying file: $IMG_DIR/$imgSpec/$rootfs\n"
-                        scp -o StrictHostKeyChecking=no -i "${ENV_ROOTDIR}/10.0.100.12-vdc-scheduler/sshkey" "$IMG_DIR/$imgSpec/$rootfs" "root@${IP_ADDR}:/var/www/html/images/$imgSpec"
-                else
-                        printf "\nFile not found: $IMG_DIR/$imgSpec/$rootfs\n"
-                fi
-        )
-}
-
-for img in "${IMAGES[@]}"
-do
-        download_container_image "${img}"
-done
-

--- a/ci/citest/acceptance-test/multibox/10.0.100.12-vdc-scheduler/build.sh
+++ b/ci/citest/acceptance-test/multibox/10.0.100.12-vdc-scheduler/build.sh
@@ -27,7 +27,6 @@ build "${IND_STEPS[@]}"
 # This is not part of the ind-steps because we don't want OpenVDC installed in
 # the cached images. We want a clean cache without OpenVDC so we can install a
 # different version to test every the CI runs.
-
 install_openvdc_yum_repo
 install_yum_package_over_ssh "openvdc-scheduler"
 enable_service_over_ssh "openvdc-scheduler"

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/common.source
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/common.source
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+meta="meta.tar.xz"
+rootfs="rootfs.tar.xz"
+
+imgHost="https://uk.images.linuxcontainers.org"
+imgHostIndex="https://uk.images.linuxcontainers.org/meta/1.0/index-system"
+imgIndex=$(curl -s "$imgHostIndex")
+
+function prepare_container_image () {
+    local img="${1}"
+    local imgSpec="${2}"
+    local remoteDir="${3}"
+
+    (
+        $starting_group "Preparing to download image: $img"
+        [ -f "$IMG_DIR/$imgSpec/$rootfs" ]
+        $skip_group_if_unnecessary; set -x
+        (
+            $starting_step "Create image dir"
+            [ -d "$IMG_DIR/$imgSpec" ];
+            $skip_step_if_already_done ; set -ex
+            mkdir -p "$IMG_DIR/$imgSpec"
+        ) ; prev_cmd_failed
+        
+        (
+            $starting_step "Downloading file: $imgHost$meta"
+            [ -f "$IMG_DIR/$imgSpec/$meta" ]
+            $skip_step_if_already_done;
+            curl -o "$IMG_DIR/$imgSpec/$meta" "$imgHost$remoteDir/$meta"
+        ) ; prev_cmd_failed
+        
+        
+        (
+            $starting_step "Downloading file: $imgHost$rootfs"
+            [ -f "$IMG_DIR/$imgSpec/$rootfs" ]
+            $skip_step_if_already_done ; set -ex
+            curl -o "$IMG_DIR/$imgSpec/$rootfs" "$imgHost$remoteDir/$rootfs"
+        ) ; prev_cmd_failed
+    ) ; prev_cmd_failed
+}
+
+function add_container_image () {
+    local img="${1}"
+    local imgSpec="${2}"
+    (
+        $starting_group "Preparing to download image: $img"
+        [[ -f "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec/$rootfs" && "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec/$meta" ]]
+        $skip_group_if_unnecessary; set -x
+
+        (
+            $starting_step "Creating folder ${NODE_DIR}/var/www/html/images/$imgSpec"
+            [ -d "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec" ]
+            $skip_step_if_already_done ; set -ex
+            mkdir -p "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec"
+        ) ; prev_cmd_failed
+        
+        (
+            $starting_step "Copying file: $IMG_DIR/$imgSpec/$meta"
+            [ -f "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec/$meta" ]
+            $skip_step_if_already_done ; set -ex
+            [ -f "$IMG_DIR/$imgSpec/$meta" ] || reportfailed "File not found: $IMG_DIR/$imgSpec/$meta"
+            cp "$IMG_DIR/$imgSpec/$meta" "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec"
+        ) ; prev_cmd_failed
+        
+        (
+            $starting_step "Copying file: $IMG_DIR/$imgSpec/$rootfs"
+            [ -f "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec/$rootfs" ]
+            $skip_step_if_already_done ; set -ex
+            [ -f "$IMG_DIR/$imgSpec/$rootfs" ] || reportfailed "File not found: $IMG_DIR/$imgSpec/$rootfs"
+            cp "$IMG_DIR/$imgSpec/$rootfs" "${NODE_DIR}/guestroot/var/www/html/images/$imgSpec"
+        ) ; prev_cmd_failed
+    ); prev_cmd_failed
+}

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/init.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+for img in "${IMAGES[@]}" ; do
+    item=$(grep "$img" <<< "$imgIndex")
+    IFS=';' read -a parts <<< "$item"
+    IFS=';' eval 'folders=($item)'
+    imgRemoteDir="${parts[-1]}"
+
+    prepare_container_image "${img}" "${folders[0]}/${folders[1]}/${folders[2]}" "$imgRemoteDir"
+    add_container_image "${img}" "${folders[0]}/${folders[1]}/${folders[2]}"
+done
+
+(
+    # resync again after images have been built
+    $starting_step "Synching guestroot for ${vm_name}"
+    # This step is set to false by default and we rely on rsyncs -u flag
+    # to take care of keeping the files updated
+    false
+    $skip_step_if_already_done; set -ex
+    sudo rsync -rv "${NODE_DIR}/guestroot/" "${TMP_ROOT}"
+) ; prev_cmd_failed

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/init.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-vdc-images/init.sh
@@ -11,7 +11,7 @@ for img in "${IMAGES[@]}" ; do
 done
 
 (
-    # resync again after images have been built
+    # resync again after images have been downloaded
     $starting_step "Synching guestroot for ${vm_name}"
     # This step is set to false by default and we rely on rsyncs -u flag
     # to take care of keeping the files updated


### PR DESCRIPTION
Refactor to make downloading of images use bashsteps to perform the tasks.
The images also gets placed in the guestroot to avoid use of scp.