### PR TITLE
TestFailedState_* fails sometime at WaitInstance() 

### DIFF
--- a/ci/citest/acceptance-test/tests/failed_state_test.go
+++ b/ci/citest/acceptance-test/tests/failed_state_test.go
@@ -28,7 +28,7 @@ func TestFailedState_StopInstance(t *testing.T) {
 
 	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "stop", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"STOPPING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"RUNNING", "STOPPING"})
 }
 
 func TestFailedState_RebootInstance(t *testing.T) {
@@ -37,7 +37,7 @@ func TestFailedState_RebootInstance(t *testing.T) {
 
 	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"REBOOTING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"RUNNING", "REBOOTING"})
 }
 
 func TestFailedState_DestroyInstance(t *testing.T) {
@@ -46,5 +46,5 @@ func TestFailedState_DestroyInstance(t *testing.T) {
 
 	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "destroy", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"SHUTTINGDOWN"})
+	WaitInstance(t, 5*time.Minute, instance_id, "FAILED", []string{"RUNNING", "SHUTTINGDOWN"})
 }


### PR DESCRIPTION
Third argument of ``WaitInstance()`` is the list of instance state which may be appeared until the goal state. The list was missing to allow the state right before issuing openvdc command.  (``RUNNING`` state in this case).

https://ci.openvdc.org/blue/rest/organizations/jenkins/pipelines/citest/branches/master/runs/201/nodes/36/log/?start=0

```
=== RUN   TestFailedState_StartInstance
--- PASS: TestFailedState_StartInstance (10.19s)
=== RUN   TestFailedState_CreateInstance
--- PASS: TestFailedState_CreateInstance (5.15s)
=== RUN   TestFailedState_StopInstance
--- PASS: TestFailedState_StopInstance (10.28s)
=== RUN   TestFailedState_RebootInstance
--- PASS: TestFailedState_RebootInstance (10.28s)
=== RUN   TestFailedState_DestroyInstance
--- FAIL: TestFailedState_DestroyInstance (10.27s)
	00_run_cmd.go:115: Unexpected Instance State: i-0000000011 goal=FAILED found=RUNNING
```