### PR TITLE
Update docs after local img merge

### DIFF
--- a/ci/citest/acceptance-test/Dockerfile
+++ b/ci/citest/acceptance-test/Dockerfile
@@ -18,7 +18,7 @@ ARG RELEASE_SUFFIX
 ARG REBUILD
 
 # Set the ARGs to ENV because otherwise they're not visible to the run_tests.sh script
-ENV BRANCH=${BRANCH:-master} RELEASE_SUFFIX=${RELEASE_SUFFIX:-current} REBUILD=${REBUILD:-true}
+ENV BRANCH=${BRANCH:-master} RELEASE_SUFFIX=${RELEASE_SUFFIX:-current} REBUILD=${REBUILD:-false}
 
 LABEL "jp.axsh.vendor"="Axsh Co. LTD"  \
       "jp.axsh.project"="OpenVDC" \

--- a/ci/citest/acceptance-test/README.md
+++ b/ci/citest/acceptance-test/README.md
@@ -2,7 +2,7 @@
 
 This is the environment used on the OpenVDC CI to run the integration tests.
 
-![Test environment drawing](illustrations/acceptance-test.svg)
+[Click here for a visual illustration of the CI environment](illustrations/acceptance-test.svg)
 
 To run this environment locally first make a file containing the following environment variables.
 

--- a/ci/citest/acceptance-test/README.md
+++ b/ci/citest/acceptance-test/README.md
@@ -45,9 +45,11 @@ Now edit `ci/citest/acceptance-test/multibox/config.source` and tell it to use t
 ```
 #BOXES_DIR="/data/openvdc-ci/boxes"
 #CACHE_DIR="/data/openvdc-ci/branches"
+#IMG_DIR="/data/openvdc-ci/images"
 
 BOXES_DIR="$HOME/work/openvdc-multibox-data/openvdc-ci/boxes"
 CACHE_DIR="$HOME/work/openvdc-multibox-data/openvdc-ci/branches"
+IMG_DIR="$HOME/work/openvdc-multibox-data/openvdc-ci/images"
 ```
 
 Now build the environment.


### PR DESCRIPTION
* The local images feature added an `IMG_DIR` variable to the config file that wasn't added to the readme. Fixed that.

* Fixed a variable's default value that was accidentally changed

* Changed the illustration in the readme from an embed to a link since SVG files aren't rendered in embeds for security reasons.