### PR TITLE
Fix local image dist argument

### DIFF
--- a/hypervisor/lxc/lxc.go
+++ b/hypervisor/lxc/lxc.go
@@ -284,6 +284,12 @@ func (d *LXCHypervisorDriver) CreateInstance() error {
 		template.Release = lxcTmpl.Release
 		template.Arch = lxcTmpl.Arch
 
+		// LXC only passes the --dist argument to the download template. That template exists to make
+		// unprivileged containers and can be used to download multiple distros. Hence the argument.
+		// https://linuxcontainers.org/lxc/getting-started/#creating-unprivileged-containers-as-a-user
+		//
+		// Since our openvdc template can also be used to download multiple distros, the argument makes sense here too.
+		template.ExtraArgs = append(template.ExtraArgs, fmt.Sprintf("--dist=%s", lxcTmpl.Distro))
 		template.ExtraArgs = append(template.ExtraArgs, fmt.Sprintf("--img-path=%s", settings.ImageServerUri))
 		template.ExtraArgs = append(template.ExtraArgs, fmt.Sprintf("--cache-path=%s", settings.CachePath))
 	default:


### PR DESCRIPTION
The local image feature requires the `--dist` argument to be passed to LXC but it seems by default LXC only passes that to the download template. Therefore we need to pass it explicitly.