### PR TITLE
Local image configuration for lxc-ovs node

### DIFF
--- a/ci/citest/acceptance-test/multibox/10.0.100.15-vdc-executor-lxc-ovs/guestroot/etc/openvdc/executor.toml
+++ b/ci/citest/acceptance-test/multibox/10.0.100.15-vdc-executor-lxc-ovs/guestroot/etc/openvdc/executor.toml
@@ -1,6 +1,8 @@
 [hypervisor]
 driver = "lxc"
 script-path = "/etc/openvdc/scripts/"
+image-server-uri = "http://10.0.100.12/images"
+cache-path = "/var/cache/lxc/"
 
 [zookeeper]
 endpoint = "zk://10.0.100.10:2181,10.0.100.11:2181,10.0.100.12:2181/openvdc"

--- a/ci/citest/acceptance-test/tests/local_image_test.go
+++ b/ci/citest/acceptance-test/tests/local_image_test.go
@@ -11,20 +11,20 @@ import (
 )
 
 func init() {
-        if err := RestoreAssets("/var/tmp", "fixtures"); err != nil {
-                panic(err)
-        }
+	if err := RestoreAssets("/var/tmp", "fixtures"); err != nil {
+		panic(err)
+	}
 }
 
 func TestLocalImage(t *testing.T) {
 
 	stdout, _, err := RunSsh(scheduler_ip, fmt.Sprintf("[ -f /var/www/html/images/centos/7/amd64/meta.tar.xz ] && echo meta.tar.xz found || echo meta.tar.xz not found"))
 
-        if err != nil {
-                t.Error(err)
-        }
+	if err != nil {
+		t.Error(err)
+	}
 
-        t.Log(stdout.String())
+	t.Log(stdout.String())
 
 	// Use custom lxc-template.
 	stdout, _ = RunCmdAndReportFail(t, "openvdc", "run", "/var/tmp/fixtures/lxc2.json", `{"node_groups":["linuxbr"]}`)


### PR DESCRIPTION
The executor running LXC and Open vSwitch didn't have the proper configuration for local images. There is currently no CI test that requires this which is why the CI was green despite this. Still I thought it was a good idea to put it in so nobody wastes time wondering why local images only work on one node in the future.

Also did a little gofmt while I was at it.