### PR TITLE
Create symlink for openvdc-executor binary to /usr/sbin

### DIFF
--- a/api/instance_service.go
+++ b/api/instance_service.go
@@ -154,7 +154,7 @@ func (s *InstanceAPI) Reboot(ctx context.Context, in *RebootRequest) (*RebootRep
 	if err := checkSupportAPI(inst.GetTemplate(), ctx); err != nil {
 		return nil, err
 	}
-	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_STOPPED); err != nil {
+	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_REBOOTING); err != nil {
 		log.WithFields(log.Fields{
 			"instance_id": in.GetInstanceId(),
 			"state":       inst.GetLastState().GetState(),

--- a/api/instance_service.go
+++ b/api/instance_service.go
@@ -156,7 +156,7 @@ func (s *InstanceAPI) Reboot(ctx context.Context, in *RebootRequest) (*RebootRep
 	if err := checkSupportAPI(inst.GetTemplate(), ctx); err != nil {
 		return nil, err
 	}
-	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_REBOOTING); err != nil {
+	if err := inst.GetLastState().ValidateNextState(model.InstanceState_REBOOTING); err != nil {
 		log.WithError(err).Error("Failed state validation")
 		return nil, err
 	}

--- a/ci/citest/acceptance-test/multibox/10.0.100.13-vdc-executor-null/guestroot/etc/mesos-slave/executor_environment_variables
+++ b/ci/citest/acceptance-test/multibox/10.0.100.13-vdc-executor-null/guestroot/etc/mesos-slave/executor_environment_variables
@@ -1,1 +1,0 @@
-{"PATH":"/opt/axsh/openvdc/bin:/usr/libexec/mesos:/usr/bin:/usr/sbin"}

--- a/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/guestroot/etc/mesos-slave/executor_environment_variables
+++ b/ci/citest/acceptance-test/multibox/10.0.100.14-vdc-executor-lxc/guestroot/etc/mesos-slave/executor_environment_variables
@@ -1,1 +1,0 @@
-{"PATH":"/opt/axsh/openvdc/bin:/usr/libexec/mesos:/usr/bin:/usr/sbin"}

--- a/ci/citest/acceptance-test/multibox/10.0.100.15-vdc-executor-lxc-ovs/guestroot/etc/mesos-slave/executor_environment_variables
+++ b/ci/citest/acceptance-test/multibox/10.0.100.15-vdc-executor-lxc-ovs/guestroot/etc/mesos-slave/executor_environment_variables
@@ -1,1 +1,0 @@
-{"PATH":"/opt/axsh/openvdc/bin:/usr/libexec/mesos:/usr/bin:/usr/sbin"}

--- a/ci/citest/acceptance-test/multibox/10.0.100.16-vdc-executor-qemu/guestroot/etc/mesos-slave/executor_environment_variables
+++ b/ci/citest/acceptance-test/multibox/10.0.100.16-vdc-executor-qemu/guestroot/etc/mesos-slave/executor_environment_variables
@@ -1,1 +1,0 @@
-{"PATH":"/opt/axsh/openvdc/bin:/usr/libexec/mesos:/usr/bin:/usr/sbin"}

--- a/ci/citest/acceptance-test/multibox/10.0.100.17-vdc-executor-qemu-ovs/guestroot/etc/mesos-slave/executor_environment_variables
+++ b/ci/citest/acceptance-test/multibox/10.0.100.17-vdc-executor-qemu-ovs/guestroot/etc/mesos-slave/executor_environment_variables
@@ -1,1 +1,0 @@
-{"PATH":"/opt/axsh/openvdc/bin:/usr/libexec/mesos:/usr/bin:/usr/sbin"}

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-epel/install.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-epel/install.sh
@@ -7,7 +7,7 @@
     [[ $? -eq 0 ]]
     $skip_step_if_already_done; set -xe
     sudo chroot "${TMP_ROOT}" /bin/bash -e <<'EOF'
-rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 EOF
 
 ) ; prev_cmd_failed

--- a/ci/citest/acceptance-test/tests/cmd_reboot_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_reboot_test.go
@@ -24,8 +24,8 @@ func TestLXCCmdReboot(t *testing.T) {
 func testCmdReboot_Ubuntu14(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- sh -c 'echo \"#!/bin/sh\\ntouch /var/local/openvdc\\n\" > /etc/rc.local; chmod 755 /etc/rc.local; sync;'", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
-	WaitUntil(t, 6 * time.Minute, func() error {
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
+	WaitUntil(t, 6*time.Minute, func() error {
 		stdout, _, _ := RunSsh(executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- runlevel", instance_id))
 		if strings.Contains(stdout.String(), "unknown") {
 			time.Sleep(3 * time.Second)
@@ -40,14 +40,14 @@ func testCmdReboot_Ubuntu16(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- systemctl enable rc-local.service", instance_id), 10, 5)
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- sh -c 'echo \"#!/bin/sh\\ntouch /var/local/openvdc\\n\" > /etc/rc.local; chmod 755 /etc/rc.local; sync;'", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- test -f /var/local/openvdc", instance_id), 10, 5)
 }
 
 func testCmdReboot_Centos7(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- chmod 755 /etc/rc.d/rc.local", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- test -f /var/lock/subsys/local", instance_id), 10, 5)
 }
 
@@ -57,7 +57,7 @@ func TestCmdReboot_QEMU(t *testing.T) {
 
 	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 
 	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
 	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
 RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
-RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 RUN yum install -y golang git createrepo
 
 

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -4,7 +4,7 @@ ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
 RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
-RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 
 RUN yum install -y git golang
 ENV GOPATH=/var/tmp/go

--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -303,13 +303,14 @@ func (exec *VDCExecutor) rebootInstance(driver exec.ExecutorDriver, instanceID s
 		return lastErr
 	}
 
-	hv, lastErr := exec.hypervisorProvider.CreateDriver(inst, inst.ResourceTemplate())
-	if lastErr != nil {
+	// .LastState must be set to REBOOTING at the API server.
+	if inst.GetLastState().GetState() != model.InstanceState_REBOOTING {
+		lastErr = errors.Errorf("Invalid instance state for reboot operation: %s", inst.GetLastState().GetState())
 		return lastErr
 	}
 
-	if lastErr = model.Instances(ctx).UpdateState(instanceID, model.InstanceState_REBOOTING); lastErr != nil {
-		log.WithError(lastErr).WithField("state", model.InstanceState_REBOOTING).Error("Failed Instances.UpdateState")
+	hv, lastErr := exec.hypervisorProvider.CreateDriver(inst, inst.ResourceTemplate())
+	if lastErr != nil {
 		return lastErr
 	}
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -53,6 +53,7 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/openvdc/scripts
 mkdir -p "$RPM_BUILD_ROOT"/etc/openvdc/ssh
 mkdir -p "$RPM_BUILD_ROOT"/usr/bin
 ln -sf /opt/axsh/openvdc/bin/openvdc  "$RPM_BUILD_ROOT"/usr/bin
+mkdir -p "$RPM_BUILD_ROOT"/usr/sbin
 ln -sf /opt/axsh/openvdc/bin/openvdc-executor  "$RPM_BUILD_ROOT"/usr/sbin
 cp openvdc "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp openvdc-executor "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -53,6 +53,7 @@ mkdir -p "$RPM_BUILD_ROOT"/etc/openvdc/scripts
 mkdir -p "$RPM_BUILD_ROOT"/etc/openvdc/ssh
 mkdir -p "$RPM_BUILD_ROOT"/usr/bin
 ln -sf /opt/axsh/openvdc/bin/openvdc  "$RPM_BUILD_ROOT"/usr/bin
+ln -sf /opt/axsh/openvdc/bin/openvdc-executor  "$RPM_BUILD_ROOT"/usr/sbin
 cp openvdc "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp openvdc-executor "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
 cp openvdc-scheduler "$RPM_BUILD_ROOT"/opt/axsh/openvdc/bin
@@ -100,6 +101,7 @@ OpenVDC executor common package.
 /opt/axsh/openvdc/share/qemu-ifdown
 %dir /etc/openvdc
 %dir /etc/openvdc/ssh
+/usr/sbin/openvdc-executor
 
 %post executor
 test ! -f /etc/openvdc/ssh/host_rsa_key && /usr/bin/ssh-keygen -q -t rsa -f /etc/openvdc/ssh/host_rsa_key -b 4096 -C '' -N '' >&/dev/null;
@@ -155,7 +157,7 @@ Summary: OpenVDC executor (Qemu driver)
 Requires: openvdc-executor
 Requires: qemu-system-x86
 Requires: dosfstools
- 
+
 %description executor-qemu
 Qemu driver configuration package for OpenVDC executor
 


### PR DESCRIPTION
mesos-slave was required to set PATH to ``/opt/axsh/openvdc/bin`` to run openvdc-executor. That results ``/etc/mesos-slave/executor_environment_variables`` configuration file must be configured.

RPM spec is updated to setup ``/usr/sbin/openvdc-executor`` symlink so that the user can forget about ``/etc/mesos-slave/executor_environment_variables`` file.