### PR TITLE
Fix update for REBOOTING state

### DIFF
--- a/api/instance_service.go
+++ b/api/instance_service.go
@@ -154,7 +154,7 @@ func (s *InstanceAPI) Reboot(ctx context.Context, in *RebootRequest) (*RebootRep
 	if err := checkSupportAPI(inst.GetTemplate(), ctx); err != nil {
 		return nil, err
 	}
-	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_STOPPED); err != nil {
+	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_REBOOTING); err != nil {
 		log.WithFields(log.Fields{
 			"instance_id": in.GetInstanceId(),
 			"state":       inst.GetLastState().GetState(),

--- a/api/instance_service.go
+++ b/api/instance_service.go
@@ -156,7 +156,7 @@ func (s *InstanceAPI) Reboot(ctx context.Context, in *RebootRequest) (*RebootRep
 	if err := checkSupportAPI(inst.GetTemplate(), ctx); err != nil {
 		return nil, err
 	}
-	if err := inst.GetLastState().ValidateGoalState(model.InstanceState_REBOOTING); err != nil {
+	if err := inst.GetLastState().ValidateNextState(model.InstanceState_REBOOTING); err != nil {
 		log.WithError(err).Error("Failed state validation")
 		return nil, err
 	}

--- a/ci/citest/acceptance-test/tests/cmd_reboot_test.go
+++ b/ci/citest/acceptance-test/tests/cmd_reboot_test.go
@@ -24,8 +24,8 @@ func TestLXCCmdReboot(t *testing.T) {
 func testCmdReboot_Ubuntu14(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- sh -c 'echo \"#!/bin/sh\\ntouch /var/local/openvdc\\n\" > /etc/rc.local; chmod 755 /etc/rc.local; sync;'", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
-	WaitUntil(t, 6 * time.Minute, func() error {
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
+	WaitUntil(t, 6*time.Minute, func() error {
 		stdout, _, _ := RunSsh(executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- runlevel", instance_id))
 		if strings.Contains(stdout.String(), "unknown") {
 			time.Sleep(3 * time.Second)
@@ -40,14 +40,14 @@ func testCmdReboot_Ubuntu16(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- systemctl enable rc-local.service", instance_id), 10, 5)
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- sh -c 'echo \"#!/bin/sh\\ntouch /var/local/openvdc\\n\" > /etc/rc.local; chmod 755 /etc/rc.local; sync;'", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- test -f /var/local/openvdc", instance_id), 10, 5)
 }
 
 func testCmdReboot_Centos7(t *testing.T, instance_id string) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- chmod 755 /etc/rc.d/rc.local", instance_id), 10, 5)
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 5*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, fmt.Sprintf("sudo lxc-attach -n %s -- test -f /var/lock/subsys/local", instance_id), 10, 5)
 }
 
@@ -57,7 +57,7 @@ func TestCmdReboot_QEMU(t *testing.T) {
 
 	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"QUEUED", "STARTING"})
 	RunCmdAndReportFail(t, "openvdc", "reboot", instance_id)
-	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"REBOOTING"})
+	WaitInstance(t, 10*time.Minute, instance_id, "RUNNING", []string{"RUNNING", "REBOOTING"})
 
 	RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
 	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)

--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -303,13 +303,14 @@ func (exec *VDCExecutor) rebootInstance(driver exec.ExecutorDriver, instanceID s
 		return lastErr
 	}
 
-	hv, lastErr := exec.hypervisorProvider.CreateDriver(inst, inst.ResourceTemplate())
-	if lastErr != nil {
+	// .LastState must be set to REBOOTING at the API server.
+	if inst.GetLastState().GetState() != model.InstanceState_REBOOTING {
+		lastErr = errors.Errorf("Invalid instance state for reboot operation: %s", inst.GetLastState().GetState())
 		return lastErr
 	}
 
-	if lastErr = model.Instances(ctx).UpdateState(instanceID, model.InstanceState_REBOOTING); lastErr != nil {
-		log.WithError(lastErr).WithField("state", model.InstanceState_REBOOTING).Error("Failed Instances.UpdateState")
+	hv, lastErr := exec.hypervisorProvider.CreateDriver(inst, inst.ResourceTemplate())
+	if lastErr != nil {
 		return lastErr
 	}
 


### PR DESCRIPTION
Reboot test fails randomly since it is difficult to find the instance's state change from the API client.

``RUNNING -> REBOOTING -> RUNNING`` is the normal transition when ``Instance.Reboot`` gRPC API was called. The client expects ``REBOOTING`` state but the instance might be still in ``RUNNING`` state. 

```
=== RUN   TestLXCCmdReboot
--- PASS: TestLXCCmdReboot (31.85s)
=== RUN   TestCmdReboot_QEMU
--- FAIL: TestCmdReboot_QEMU (111.18s)
	00_run_cmd.go:60: STDOUT:
	00_run_cmd.go:61: STDERR:
		time="2017-07-18T15:31:13Z" level=fatal msg="Disconnected abnormally" error="rpc error: code = 2 desc = Invalid goal state: REBOOTING -> TERMINATED" 
	00_run_cmd.go:64: Running 'openvdc' failed. Tried 10 times.
=== RUN   TestCmdRun_NullTemplate
```