### PR TITLE
Build with Go 1.8

### DIFF
--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 RUN yum install -y git createrepo
 
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV GOPATH=/var/tmp/go PATH=$PATH:$GOPATH/bin
+ENV GOPATH=/var/tmp/go PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH
 RUN go get -u github.com/kardianos/govendor
 RUN mkdir -p /var/tmp/go/src/github.com/axsh/openvdc

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -2,7 +2,6 @@ FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
-RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 RUN yum install -y git createrepo

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -7,6 +7,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 RUN yum install -y git createrepo
 
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN yum install gcc
 ENV GOPATH=/var/tmp/go PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH
 RUN go get -u github.com/kardianos/govendor

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 RUN yum install -y git createrepo
 
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-RUN yum install gcc
+RUN yum install -y gcc
 ENV GOPATH=/var/tmp/go PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH
 RUN go get -u github.com/kardianos/govendor

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -5,9 +5,9 @@ RUN yum install -y yum-utils
 RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
-RUN yum install -y golang git createrepo
+RUN yum install -y git createrepo
 
-
+RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV GOPATH=/var/tmp/go PATH=$PATH:$GOPATH/bin
 RUN mkdir $GOPATH
 RUN go get -u github.com/kardianos/govendor

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -6,7 +6,8 @@ RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 
-RUN yum install -y git golang
+RUN yum install -y git
+RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV GOPATH=/var/tmp/go
 ENV PATH=$PATH:$GOPATH/bin
 RUN mkdir $GOPATH

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 RUN yum install -y git
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV GOPATH=/var/tmp/go
-ENV PATH=$PATH:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH
 
 RUN mkdir -p $GOPATH/src/github.com/axsh/openvdc

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 
 RUN yum install -y git
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-RUN yum install gcc
+RUN yum install -y gcc
 ENV GOPATH=/var/tmp/go
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -7,6 +7,7 @@ RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-
 
 RUN yum install -y git
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN yum install gcc
 ENV GOPATH=/var/tmp/go
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 RUN mkdir $GOPATH

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -2,7 +2,6 @@ FROM centos:7
 WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
-RUN yum-config-manager --enable centosplus
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
 RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -14,7 +14,8 @@ License: LGPLv3
 BuildArch: x86_64
 
 BuildRequires: rpmdevtools lxc-devel git
-BuildRequires: golang >= 1.7
+# CentOS 7.3 does not have official Go 1.8 package.
+#BuildRequires: golang >= 1.8
 
 Requires: mesosphere-zookeeper mesos
 Requires: bridge-utils


### PR DESCRIPTION
There is no official Go 1.8 release for CentOS. Dockerfile for build stages was modified to install the compiler manually from golang.org.