### PR TITLE
Fix local image tar issue

### DIFF
--- a/cmd/lxc-openvdc/main.go
+++ b/cmd/lxc-openvdc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -9,13 +10,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
-	"github.com/mholt/archiver"
 	"github.com/pkg/errors"
 )
 
@@ -215,13 +216,20 @@ func CreateCacheFolder(folderPath string) error {
 }
 
 func DecompressXz(fileName string, outputPath string) error {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 
 	filePath := filepath.Join(cacheFolderPath, fileName)
 
-	err := archiver.TarXZ.Open(filePath, outputPath)
+	cmd := exec.Command("tar", "-xf", filePath, "-C", outputPath)
+	cmd.Stdout = &stdout
+	cmd.Stdout = &stderr
+
+	err := cmd.Run()
 
 	if err != nil {
-		return errors.Wrapf(err, "Failed unpacking file: %s.", filePath)
+		return errors.Wrapf(err, "Failed unpacking file: %s.\nStdout: %s\nStderr: %s\n",
+			filePath, stdout.String(), stderr.String())
 	}
 
 	return nil

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -134,6 +134,8 @@ Requires: lxc
 # lxc-templates does not resolve its sub dependencies
 Requires: lxc-templates wget gpg sed gawk coreutils rsync debootstrap dropbear
 Requires: iproute
+# Needed for unpacking local images
+Requires: tar xz
 
 %description executor-lxc
 LXC driver configuration package for OpenVDC executor.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -328,12 +328,6 @@
 			"revisionTime": "2016-10-04T19:21:23Z"
 		},
 		{
-			"checksumSHA1": "M6+Y7O6DEpfuJbhHAU7HYQjsk3o=",
-			"path": "github.com/mholt/archiver",
-			"revision": "c55f48c22890807c9698370fe5e08eca3704834b",
-			"revisionTime": "2017-02-16T13:00:38Z"
-		},
-		{
 			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "756f7b183b7ab78acdbbee5c7f392838ed459dda",


### PR DESCRIPTION
Mholt's archiver library that we were using to unpack the LXC rootfs tarball wasn't quite getting the job done. A rootfs contains a bunch of device nodes and other special files in the `/dev` directory. This library couldn't handle those properly and just wrote empty files instead.

I've checked out a couple other implementations but most seemed to just read the tarball, iterate over the files in it and then write new files with the same name and contents. While this works for the most basic archives, tarballs keep a lot more info such as ownership, permissions, etc.

I discussed with @unakatsuo and we decided to just use the tar command directly as there seems to be no sufficient go implementation and it's a safe bet that this lxc template will never be used outside of Linux.