### PR TITLE
Fix stdour/stderr mistake in local image lxc template

### DIFF
--- a/cmd/lxc-openvdc/main.go
+++ b/cmd/lxc-openvdc/main.go
@@ -223,7 +223,7 @@ func DecompressXz(fileName string, outputPath string) error {
 
 	cmd := exec.Command("tar", "-xf", filePath, "-C", outputPath)
 	cmd.Stdout = &stdout
-	cmd.Stdout = &stderr
+	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 


### PR DESCRIPTION
Just noticed that I was setting stdout only to immediately overwrite it with stderr. Fixed that.