### PR TITLE
Fix race scheduling

### DIFF
--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -126,8 +126,8 @@ func (exec *VDCExecutor) bootInstance(driver exec.ExecutorDriver, taskInfo *meso
 		return errors.Wrap(err, "Failed model.Instance.FindByID")
 	}
 	// Assert the race for scheduling slave and instance.
-	if inst.GetSlaveId() != taskInfo.GetSlaveId().String() {
-		log.Fatalf("Found mismatch for SlaveID assignment between instance and Mesos message: instance expects %s but Mesos says %s",
+	if inst.GetSlaveId() != taskInfo.GetSlaveId().GetValue() {
+		log.Fatalf("BUGON: Found mismatch for SlaveID assignment between instance and Mesos message: instance expects %s but Mesos says %s",
 			inst.GetSlaveId(),
 			taskInfo.GetSlaveId().String())
 	}

--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -121,6 +121,17 @@ func (exec *VDCExecutor) bootInstance(driver exec.ExecutorDriver, taskInfo *meso
 		return err
 	}
 
+	inst, err := model.Instances(ctx).FindByID(instanceID)
+	if err != nil {
+		return errors.Wrap(err, "Failed model.Instance.FindByID")
+	}
+	// Assert the race for scheduling slave and instance.
+	if inst.GetSlaveId() != taskInfo.GetSlaveId().String() {
+		log.Fatalf("Found mismatch for SlaveID assignment between instance and Mesos message: instance expects %s but Mesos says %s",
+			inst.GetSlaveId(),
+			taskInfo.GetSlaveId().String())
+	}
+
 	// Apply FAILED terminal state in case of error.
 	finState := model.InstanceState_FAILED
 	var lastErr error
@@ -141,7 +152,8 @@ func (exec *VDCExecutor) bootInstance(driver exec.ExecutorDriver, taskInfo *meso
 		return lastErr
 	}
 
-	inst, lastErr := model.Instances(ctx).FindByID(instanceID)
+	// Reload instance object from datastore.x
+	inst, lastErr = model.Instances(ctx).FindByID(instanceID)
 	if lastErr != nil {
 		log.WithError(lastErr).Error("Failed Instances.FindyByID")
 		return lastErr

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -178,6 +178,10 @@ func (sched *VDCScheduler) processOffers(driver sched.SchedulerDriver, offers []
 	tasks := []*mesos.TaskInfo{}
 	acceptIDs := []*mesos.OfferID{}
 	for _, i := range queued {
+		if i.SlaveId != "" {
+			log.WithField("instance_id", i.GetId()).Warnf("Skipping the instance with QUEUED but SlaveID is assigned: %s", i.SlaveId)
+			continue
+		}
 		found := findMatching(i)
 		for i, _ := range acceptIDs {
 			if acceptIDs[i] == found.Id {


### PR DESCRIPTION
Scheduler sometime listed the QUEUED instances which have done scheduling when it got many ``openvdc run`` request.