### PR TITLE
Fix local merge in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ SHA=${SHA}
 
 def checkout_and_merge() {
     checkout scm
+    sh "git fetch --no-tags --progress origin +refs/heads/master:refs/remotes/origin/master"
     sh "git -c \"user.name=Axsh Bot\" -c \"user.email=dev@axsh.net\" merge origin/master"
 }
 


### PR DESCRIPTION
Jenkins was failing with this message on every branch:

```
+ git -c 'user.name=Axsh Bot' -c user.email=dev@axsh.net merge origin/master
fatal: origin/master - not something we can merge
```

The reason is that jenkins is fetching *only* the branch it wants to tests and thus `origin/master` doesn't exist.

```
# Current behaviour
git fetch --no-tags --progress https://github.com/axsh/openvdc.git +refs/heads/esxi-driver:refs/remotes/origin/esxi-driver
Checking out Revision 1018b9a3657edb0bbf27e8d801918394f801bef0 (esxi-driver)
```

The reason why this problem didn't occur before is because Jenkins used to fetch all branches rather than just the one it wants to test.

```
# Past behaviour
git fetch --tags --progress https://github.com/axsh/openvdc.git +refs/pull/*/head:refs/remotes/origin/pr/*
Checking out Revision 5e76df693ab85d268b91c2f772f9ff81ca7d5454 (console_auth)
```

I have no idea why this behaviour changed. I can only assume that the git plugin for Jenkins must have been updated. Either one of us did it or it has auto updates enabled. In any case I fixed it by fetching `origin/master` specifically before attempting to merge it.