### PR TITLE
Fixed a small SSH key issue on the CI

### DIFF
--- a/ci/citest/acceptance-test/multibox/ind-steps/step-ssh/boot.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-ssh/boot.sh
@@ -2,7 +2,9 @@
 
 (
     $starting_step "Import ssh key"
-    [ -f ${NODE_DIR}/sshkey ]
+    # If we had built another branch before, its ssh key will still be in place.
+    # That's why we always do this step even if there's a key already.
+    false
     $skip_step_if_already_done
     cp ${CACHE_DIR}/${BRANCH}/sshkey_${vm_name} ${NODE_DIR}/sshkey
     chown ${USER}:${USER} ${NODE_DIR}/sshkey


### PR DESCRIPTION
When the CI environment gets cached for a branch, the correct SSH keys are cached with it.

I've been running the environment locally to test multiple branches and noticed the wrong key gets used some times.

### Problem

* Build the environment on branch A
* Branch A gets cached with the correct ssh keys
* Destroy the environment on branch A, leaving cache
* Build the environment on branch B
* The build script will see that there is already an SSH key (branch A's) present and not copy over B's ssh key
* SSH fails

### Solution

* Don't check if an SSH key is present and just always copy over the correct cached key