### PR TITLE
Fix epel

### DIFF
--- a/ci/citest/acceptance-test/multibox/ind-steps/step-epel/pre_boot.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-epel/pre_boot.sh
@@ -6,6 +6,7 @@
         "rpm -qa epel-release* | egrep -q epel-release"
     [[ $? -eq 0 ]]
     $skip_step_if_already_done; set -xe
+    # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
     sudo chroot "${TMP_ROOT}" /bin/bash -e <<'EOF'
 rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 EOF

--- a/ci/citest/acceptance-test/multibox/ind-steps/step-epel/pre_boot.sh
+++ b/ci/citest/acceptance-test/multibox/ind-steps/step-epel/pre_boot.sh
@@ -7,7 +7,7 @@
     [[ $? -eq 0 ]]
     $skip_step_if_already_done; set -xe
     sudo chroot "${TMP_ROOT}" /bin/bash -e <<'EOF'
-rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 EOF
 
 ) ; prev_cmd_failed

--- a/ci/citest/rpmbuild/el7.Dockerfile
+++ b/ci/citest/rpmbuild/el7.Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
-RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 RUN yum install -y git createrepo
 
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -

--- a/ci/citest/unit-tests/el7-unit-tests.Dockerfile
+++ b/ci/citest/unit-tests/el7-unit-tests.Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /var/tmp
 ENTRYPOINT ["/sbin/init"]
 RUN yum install -y yum-utils
 # epel-release.rpm from CentOS/extra contains deprecated index for mirror sites.
-RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+RUN yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
 
 RUN yum install -y git
 RUN curl -L https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -


### PR DESCRIPTION
The epel-release package has had an update and the old link's dead. I updated our scripts accordingly. It's probably a good idea to try a simple `yum install epel-release` again so we don't have to deal with this in the future. That should be done in another PR though as first of all we should just get the CI working again.

Ps: The CI is only affected by this when we set `REBUILD=true` since otherwise it will just re-use the cache that already has the older version of epel installed.