### PR TITLE
Mesos resource config

### DIFF
--- a/cmd/openvdc-executor/main.go
+++ b/cmd/openvdc-executor/main.go
@@ -174,6 +174,9 @@ func (exec *VDCExecutor) bootInstance(driver exec.ExecutorDriver, taskInfo *meso
 			log.WithError(err).WithField("state", finState).Error("Failed Instances.UpdateState")
 		}
 		if finState == model.InstanceState_FAILED {
+			if err := model.Instances(ctx).UpdateConnectionStatus(instanceID, model.ConnectionStatus_NOT_CONNECTED); err != nil {
+				log.WithError(err).Errorf("Couldn't update instance connectionStatus. instanceID: %s connectionStatus: %s", instanceID, model.ConnectionStatus_NOT_CONNECTED)
+			}
 			recordFailedState(ctx, driver, instanceID, model.FailureMessage_FAILED_BOOT, lastErr)
 		}
 		log.WithField("fin_state", finState).Info("Proceeded defer func() at bootInstance()")
@@ -238,6 +241,9 @@ func (exec *VDCExecutor) startInstance(driver exec.ExecutorDriver, instanceID st
 	var lastErr error
 	defer func() {
 		if finState == model.InstanceState_FAILED {
+			if err := model.Instances(ctx).UpdateConnectionStatus(instanceID, model.ConnectionStatus_NOT_CONNECTED); err != nil {
+				log.WithError(err).Errorf("Couldn't update instance connectionStatus. instanceID: %s connectionStatus: %s", instanceID, model.ConnectionStatus_NOT_CONNECTED)
+			}
 			recordFailedState(ctx, driver, instanceID, model.FailureMessage_FAILED_START, lastErr)
 		}
 		if err := model.Instances(ctx).UpdateState(instanceID, finState); err != nil {
@@ -297,9 +303,13 @@ func (exec *VDCExecutor) stopInstance(driver exec.ExecutorDriver, instanceID str
 	var lastErr error
 	defer func() {
 		if finState == model.InstanceState_FAILED {
+			if err := model.Instances(ctx).UpdateConnectionStatus(instanceID, model.ConnectionStatus_NOT_CONNECTED); err != nil {
+				log.WithError(err).Errorf("Couldn't update instance connectionStatus. instanceID: %s connectionStatus: %s", instanceID, model.ConnectionStatus_NOT_CONNECTED)
+			}
 			recordFailedState(ctx, driver, instanceID, model.FailureMessage_FAILED_STOP, lastErr)
 		}
 		if err := model.Instances(ctx).UpdateState(instanceID, finState); err != nil {
+
 			log.WithError(err).WithField("state", finState).Error("Failed Instances.UpdateState")
 		}
 		model.Close(ctx)
@@ -402,6 +412,9 @@ func (exec *VDCExecutor) terminateInstance(driver exec.ExecutorDriver, instanceI
 	finState := model.InstanceState_FAILED
 	var lastErr error
 	defer func() {
+		if err := model.Instances(ctx).UpdateConnectionStatus(instanceID, model.ConnectionStatus_NOT_CONNECTED); err != nil {
+			log.WithError(err).Errorf("Couldn't update instance connectionStatus. instanceID: %s connectionStatus: %s", instanceID, model.ConnectionStatus_NOT_CONNECTED)
+		}
 		if finState == model.InstanceState_FAILED {
 			recordFailedState(ctx, driver, instanceID, model.FailureMessage_FAILED_TERMINATE, lastErr)
 		}

--- a/docs/computing_resources.md
+++ b/docs/computing_resources.md
@@ -1,0 +1,50 @@
+# Computing resources
+
+OpenVDC uses the mesos frameworks resource handling to keep track of available
+cpu/memory on each executor. By default the values are fetched from the
+physical resources available on the host running the executor.
+
+Depending on the hypervisor driver being used, we need to manually define the
+resources available.
+
+* LXC are simple containers and does not fully virtualize memory/cpu.
+Resource configuration is not required unless there is a reason to restrict the
+resources offered.
+
+* Qemu assigns virtual cpu cores to instances booted. Here we can overwrite the
+default cpus value to a larger number since we are not using physical cores for
+our instances. Memory is calculated based on the available memory when the agent
+is started and should be left alone as it is a physical resource.
+
+* ESXi requires the executor to run on a remote host. In this case all computing
+resources needs to be set manually as the mesos agent is only able to fetch local
+resources. Like with qemu cpus are virtual resources and can be overwritten to
+fit requirements. Memory should be set to match the available memory on the
+ESXi host.
+
+
+To overwrite the default values create `/etc/mesos-slave/resources` before
+starting the mesos-slave agent
+
+Following is a basic example
+
+```
+[
+  {
+    "name": "cpus",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 20
+    }
+  },
+  {
+    "name": "mem",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 20480
+    }
+  }
+]
+```
+
+reference http://mesos.apache.org/documentation/latest/attributes-resources/

--- a/pkg/conf/mesos-slave/resources
+++ b/pkg/conf/mesos-slave/resources
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "cpus",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 20
+    }
+  },
+  {
+    "name": "mem",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 20480
+    }
+  },
+  {
+    "name": "disk",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 409600
+    }
+  }
+]

--- a/pkg/conf/mesos-slave/resources.esxi
+++ b/pkg/conf/mesos-slave/resources.esxi
@@ -12,12 +12,5 @@
     "scalar": {
       "value": 20480
     }
-  },
-  {
-    "name": "disk",
-    "type": "SCALAR",
-    "scalar": {
-      "value": 409600
-    }
   }
 ]

--- a/pkg/conf/mesos-slave/resources.qemu
+++ b/pkg/conf/mesos-slave/resources.qemu
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "cpus",
+    "type": "SCALAR",
+    "scalar": {
+      "value": 20
+    }
+  }
+]

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -70,7 +70,7 @@ mkdir -p "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/lxc-templates
 cp lxc-openvdc "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/lxc-templates/lxc-openvdc"
 cp qemu-ifup "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/"
 cp qemu-ifdown "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/"
-install -p -t "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/mesos-slave pkg/conf/mesos-slave/attributes.null pkg/conf/mesos-slave/attributes.lxc pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/attributes.esxi
+install -p -t "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/mesos-slave pkg/conf/mesos-slave/attributes.null pkg/conf/mesos-slave/attributes.lxc pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/attributes.esxi pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/resources.qemu pkg/conf/mesos-slave/resources.esxi
 
 %package cli
 Summary: OpenVDC cli

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -70,7 +70,7 @@ mkdir -p "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/lxc-templates
 cp lxc-openvdc "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/lxc-templates/lxc-openvdc"
 cp qemu-ifup "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/"
 cp qemu-ifdown "${RPM_BUILD_ROOT}/opt/axsh/openvdc/share/"
-install -p -t "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/mesos-slave pkg/conf/mesos-slave/attributes.null pkg/conf/mesos-slave/attributes.lxc pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/attributes.esxi pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/resources.qemu pkg/conf/mesos-slave/resources.esxi
+install -p -t "$RPM_BUILD_ROOT"/opt/axsh/openvdc/share/mesos-slave pkg/conf/mesos-slave/attributes.null pkg/conf/mesos-slave/attributes.lxc pkg/conf/mesos-slave/attributes.qemu pkg/conf/mesos-slave/attributes.esxi pkg/conf/mesos-slave/resources.qemu pkg/conf/mesos-slave/resources.esxi
 
 %package cli
 Summary: OpenVDC cli

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -100,7 +100,8 @@ OpenVDC executor common package.
 /opt/axsh/openvdc/share/mesos-slave/attributes.lxc
 /opt/axsh/openvdc/share/mesos-slave/attributes.qemu
 /opt/axsh/openvdc/share/mesos-slave/attributes.esxi
-/opt/axsh/openvdc/share/mesos-slave/resources
+/opt/axsh/openvdc/share/mesos-slave/resources.qemu
+/opt/axsh/openvdc/share/mesos-slave/resources.esxi
 /opt/axsh/openvdc/share/lxc-templates/lxc-openvdc
 /opt/axsh/openvdc/share/qemu-ifup
 /opt/axsh/openvdc/share/qemu-ifdown
@@ -112,13 +113,6 @@ OpenVDC executor common package.
 test ! -f /etc/openvdc/ssh/host_rsa_key && /usr/bin/ssh-keygen -q -t rsa -f /etc/openvdc/ssh/host_rsa_key -b 4096 -C '' -N '' >&/dev/null;
 test ! -f /etc/openvdc/ssh/host_ecdsa_key && /usr/bin/ssh-keygen -q -t ecdsa -f /etc/openvdc/ssh/host_ecdsa_key -C '' -N '' >&/dev/null;
 test ! -f /etc/openvdc/ssh/host_ed25519_key && /usr/bin/ssh-keygen -q -t ed25519 -f /etc/openvdc/ssh/host_ed25519_key -C '' -N '' >&/dev/null;
-if [ -d /etc/mesos-slave ]; then
-  if [ ! -f /etc/mesos-slave/resources ]; then
-    cp -p /opt/axsh/openvdc/share/mesos-slave/resources /etc/mesos-slave/resources
-  fi
-fi
-
-
 
 %package executor-null
 Summary: OpenVDC executor (null driver)
@@ -183,7 +177,14 @@ if [ -d /etc/mesos-slave ]; then
   if [ ! -f /etc/mesos-slave/attributes ]; then
     cp -p /opt/axsh/openvdc/share/mesos-slave/attributes.qemu /etc/mesos-slave/attributes
   fi
+
+  if [ ! -f /etc/mesos-slave/resources ]; then
+    cp -p /opt/axsh/openvdc/share/mesos-slave/resources.qemu /etc/mesos-slave/resources
+  fi
 fi
+
+
+
 
 cp /opt/axsh/openvdc/share/qemu-ifup /etc/
 cp /opt/axsh/openvdc/share/qemu-ifdown /etc/
@@ -203,6 +204,10 @@ Esxi driver configuration package for OpenVDC executor
 if [ -d /etc/mesos-slave ]; then
   if [ ! -f /etc/mesos-slave/attributes ]; then
     cp -p /opt/axsh/openvdc/share/mesos-slave/attributes.esxi /etc/mesos-slave/attributes
+  fi
+
+  if [ ! -f /etc/mesos-slave/resources ]; then
+    cp -p /opt/axsh/openvdc/share/mesos-slave/resources.esxi /etc/mesos-slave/resources
   fi
 fi
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -183,9 +183,6 @@ if [ -d /etc/mesos-slave ]; then
   fi
 fi
 
-
-
-
 cp /opt/axsh/openvdc/share/qemu-ifup /etc/
 cp /opt/axsh/openvdc/share/qemu-ifdown /etc/
 

--- a/pkg/rhel/openvdc.spec
+++ b/pkg/rhel/openvdc.spec
@@ -100,6 +100,7 @@ OpenVDC executor common package.
 /opt/axsh/openvdc/share/mesos-slave/attributes.lxc
 /opt/axsh/openvdc/share/mesos-slave/attributes.qemu
 /opt/axsh/openvdc/share/mesos-slave/attributes.esxi
+/opt/axsh/openvdc/share/mesos-slave/resources
 /opt/axsh/openvdc/share/lxc-templates/lxc-openvdc
 /opt/axsh/openvdc/share/qemu-ifup
 /opt/axsh/openvdc/share/qemu-ifdown
@@ -111,6 +112,13 @@ OpenVDC executor common package.
 test ! -f /etc/openvdc/ssh/host_rsa_key && /usr/bin/ssh-keygen -q -t rsa -f /etc/openvdc/ssh/host_rsa_key -b 4096 -C '' -N '' >&/dev/null;
 test ! -f /etc/openvdc/ssh/host_ecdsa_key && /usr/bin/ssh-keygen -q -t ecdsa -f /etc/openvdc/ssh/host_ecdsa_key -C '' -N '' >&/dev/null;
 test ! -f /etc/openvdc/ssh/host_ed25519_key && /usr/bin/ssh-keygen -q -t ed25519 -f /etc/openvdc/ssh/host_ed25519_key -C '' -N '' >&/dev/null;
+if [ -d /etc/mesos-slave ]; then
+  if [ ! -f /etc/mesos-slave/resources ]; then
+    cp -p /opt/axsh/openvdc/share/mesos-slave/resources /etc/mesos-slave/resources
+  fi
+fi
+
+
 
 %package executor-null
 Summary: OpenVDC executor (null driver)

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -346,6 +346,10 @@ func (sched *VDCScheduler) NewExecutor(hypervisorName string) *mesos.ExecutorInf
 			Value: proto.String(fmt.Sprintf("%s --hypervisor=%s --zk=%s",
 				ExecutorPath, hypervisorName, sched.zkAddr.String())),
 		},
+		Resources: []*mesos.Resource{
+			util.NewScalarResource("cpus", 0.01),
+			util.NewScalarResource("mem", 32),
+		},
 	}
 	return executor
 }


### PR DESCRIPTION
ESXi and Qemu drivers does not use physical cpus as resources, in addition since the ESXi executor runs on a remote host the memory needs to be set manually.

Added a default resources configuration file for the mesos agent that overwrites the default values along with some documentation. I also added the minimum resources that mesos recommends that you give to the executor.