### PR TITLE
Fix serial connection

### DIFF
--- a/hypervisor/util/serial_connection.go
+++ b/hypervisor/util/serial_connection.go
@@ -46,7 +46,11 @@ func (sc *SerialConnection) stdinToConn(param *serialConsoleParam, finished <-ch
 	param.waitClosed.Add(1)
 	defer func() {
 		param.closeChan <-true
-		param.errc <-sc
+		if sc.err != nil {
+			param.errc <-sc
+		} else {
+			param.errc <-nil
+		}
 		param.waitClosed.Done()
 	}()
 
@@ -87,7 +91,11 @@ func (sc *SerialConnection) connToStdout(param *serialConsoleParam, finished <-c
 	param.waitClosed.Add(1)
 	defer func() {
 		param.closeChan <-true
-		param.errc <-sc
+		if sc.err != nil {
+			param.errc <-sc
+		} else {
+			param.errc <-nil
+		}
 		param.waitClosed.Done()
 	}()
 
@@ -127,7 +135,7 @@ func (sc *SerialConnection) Error() string {
 }
 
 func (sc *SerialConnection) ExitCode() int {
-	if sc.err != nil && != sc.err != io.EOF {
+	if sc.err != nil && sc.err != io.EOF {
 		return 1
 	}
 	return 0

--- a/hypervisor/util/serial_connection.go
+++ b/hypervisor/util/serial_connection.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"fmt"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,6 +16,7 @@ import (
 
 type SerialConnection struct {
 	SerialConn net.Conn
+	err        error
 }
 
 type serialConsoleParam struct {
@@ -25,11 +27,10 @@ type serialConsoleParam struct {
 }
 
 func (sc *SerialConnection) stdinToConn(param *serialConsoleParam, finished <-chan struct{}) {
-	var err error
 	param.waitClosed.Add(1)
 	defer func() {
 		param.closeChan <-true
-		param.errc <-err
+		param.errc <-sc
 		param.waitClosed.Done()
 	}()
 
@@ -46,6 +47,7 @@ func (sc *SerialConnection) stdinToConn(param *serialConsoleParam, finished <-ch
 				} else {
 					log.WithError(err).Error("Failed to read from the from the console input buffer")
 				}
+				sc.err = err
 				return
 			}
 
@@ -54,9 +56,9 @@ func (sc *SerialConnection) stdinToConn(param *serialConsoleParam, finished <-ch
 				return
 			}
 
-			_, err = sc.SerialConn.Write(b[0:n])
-			if err != nil {
+			if _, err := sc.SerialConn.Write(b[0:n]); err != nil {
 				log.WithError(err).Error("Failed to write to the connection from the buffer")
+				sc.err = err
 				return
 			}
 		}
@@ -64,19 +66,10 @@ func (sc *SerialConnection) stdinToConn(param *serialConsoleParam, finished <-ch
 }
 
 func (sc *SerialConnection) connToStdout(param *serialConsoleParam, finished <-chan struct{}) {
-	var err error
 	param.waitClosed.Add(1)
 	defer func() {
-		if _, err = param.remoteConsole.Stdout.Write([]byte{0x0A}); err != nil {
-			if err == io.EOF {
-				err = nil
-			} else {
-				log.WithError(err).Error("Failed to write the linefeed character on exit")
-			}
-		}
-
 		param.closeChan <-true
-		param.errc <-err
+		param.errc <-sc
 		param.waitClosed.Done()
 	}()
 
@@ -84,41 +77,49 @@ func (sc *SerialConnection) connToStdout(param *serialConsoleParam, finished <-c
 	for {
 		sc.SerialConn.SetDeadline(time.Now().Add(time.Second))
 		n, err := sc.SerialConn.Read(b)
+		if err == io.EOF {
+			sc.err = errors.New("connection lost")
+			return
+		}
 
 		select {
 		case <-finished:
 			return
 		default:
-			if err == io.EOF {
-				_, err = param.remoteConsole.Stdout.Write([]byte("\nConnection lost\n"))
-				if err != nil && err != io.EOF {
-					log.WithError(err).Error("Failed to write the linefeed character on exit")
-					return
-				}
-
-				log.Info("Connection released, received EOF")
-				return
-			}
 			if err != nil && !err.(net.Error).Timeout() {
 				log.WithError(err).Error("Failed to read the connection buffer from socket")
+				sc.err = err
 				return
 			}
 			// exit on ctrl + q
 			if bytes.Contains(b[0:n], []byte{0x11}) {
 				return
 			}
+
 			if synchable, ok := param.remoteConsole.Stdout.(*os.File); ok {
 				if err := synchable.Sync(); err != nil {
 					log.Warn("Failed %v to flush %s", param.remoteConsole.Stdout, err)
 				}
 			}
 			_, err = param.remoteConsole.Stdout.Write(b[0:n])
-			if err != nil {
+			if err != nil{
 				log.WithError(err).Error("Failed to write to the console stdout buffer")
+				sc.err = err
 				return
 			}
 		}
 	}
+}
+
+func (sc *SerialConnection) Error() string {
+	return fmt.Sprintf("Serial console failed: %v", sc.err)
+}
+
+func (sc *SerialConnection) ExitCode() int {
+	if sc.err != nil && != sc.err != io.EOF {
+		return 1
+	}
+	return 0
 }
 
 func (sc *SerialConnection) AttachSerialConsole(param *hypervisor.ConsoleParam, waitClosed *sync.WaitGroup, errc chan error) error {
@@ -139,6 +140,11 @@ func (sc *SerialConnection) AttachSerialConsole(param *hypervisor.ConsoleParam, 
 	go func() {
 		<-serialConsoleParam.closeChan
 		close(finished)
+
+		_, err := serialConsoleParam.remoteConsole.Stdout.Write([]byte{0x0A})
+		if err != nil && err != io.EOF {
+			log.WithError(err).Warn("Failed to write the linefeed character on exit")
+		}
 	}()
 
 	return nil

--- a/hypervisor/util/serial_connection.go
+++ b/hypervisor/util/serial_connection.go
@@ -17,75 +17,79 @@ type SerialConnection struct {
 	SerialConn net.Conn
 }
 
-func (sc *SerialConnection) AttachSerialConsole(param *hypervisor.ConsoleParam, waitClosed *sync.WaitGroup, errc chan error) error {
+func (sc *SerialConnection) stdinToConn(param *hypervisor.ConsoleParam, waitClosed *sync.WaitGroup, errc chan error) {
 	waitClosed.Add(1)
-	go func() {
-		defer waitClosed.Done()
-		b := make([]byte, 8192) // 8 kB is the default page size for most modern file systems
-		for {
-			select {
-			case err := <-errc:
-				 errc <- err
-				break
-			default:
-				n, err := param.Stdin.Read(b)
-				if err != nil {
-					if err == io.EOF {
-						log.Info("\nConsole exited by EOF\n\n")
-						errc <- nil
-					} else {
-						errc <- errors.Wrap(err, "\nFailed to read from the from the console input buffer\n\n")
-					}
-				}
-
-				if bytes.Contains(b[0:n], []byte{0x11}) {
-					log.Info("\nConsole exited by ctrl-q\n\n")
+	defer waitClosed.Done()
+	b := make([]byte, 8192) // 8 kB is the default page size for most modern file systems
+	for {
+		select {
+		case err := <-errc:
+			errc <- err
+			break
+		default:
+			n, err := param.Stdin.Read(b)
+			if err != nil {
+				if err == io.EOF {
+					log.Info("\nConsole exited by EOF\n\n")
 					errc <- nil
-				}
-				_, err = sc.SerialConn.Write(b[0:n])
-				if err != nil {
-					errc <- errors.Wrap(err, "\nFailed to write to the connection from the buffer\n\n")
-				}
-			}
-		}
-	}()
-
-	waitClosed.Add(1)
-	go func() {
-		defer waitClosed.Done()
-		b := make([]byte, 8192)
-		for {
-			sc.SerialConn.SetDeadline(time.Now().Add(time.Second))
-			n, err := sc.SerialConn.Read(b)
-			select {
-			case err := <-errc:
-				if _, e := param.Stdout.Write([]byte{0x0A}); e != nil {
-					errc <- errors.Wrap(e, "\nFailed to write the linefeed character on exit\n\n")
 				} else {
-					errc <- err
-				}
-				break
-			default:
-				if err != nil && !err.(net.Error).Timeout() {
-					errc <- errors.Wrap(err, "\nFailed to read the connection buffer from socket ")
-				}
-				// exit on ctrl + q
-				if bytes.Contains(b[0:n], []byte{0x11}) {
-					errc <- nil
-				}
-
-				if synchable, ok := param.Stdout.(*os.File); ok {
-					if err := synchable.Sync(); err != nil {
-						log.Warn("Failed %v to flush %s", param.Stdout, err)
-					}
-				}
-				_, err = param.Stdout.Write(b[0:n])
-				if err != nil {
-					errc <- errors.Wrap(err, "\nFailed to write to the console stdout buffer\n\n")
+					errc <- errors.Wrap(err, "\nFailed to read from the from the console input buffer\n\n")
 				}
 			}
+
+			if bytes.Contains(b[0:n], []byte{0x11}) {
+				log.Info("\nConsole exited by ctrl-q\n\n")
+				errc <- nil
+			}
+			_, err = sc.SerialConn.Write(b[0:n])
+			if err != nil {
+				errc <- errors.Wrap(err, "\nFailed to write to the connection from the buffer\n\n")
+			}
 		}
-	}()
+	}
+}
+
+func (sc *SerialConnection) connToStdout(param *hypervisor.ConsoleParam, waitClosed *sync.WaitGroup, errc chan error) {
+	waitClosed.Add(1)
+	defer waitClosed.Done()
+	b := make([]byte, 8192)
+	for {
+		sc.SerialConn.SetDeadline(time.Now().Add(time.Second))
+		n, err := sc.SerialConn.Read(b)
+		select {
+		case err := <-errc:
+			if _, e := param.Stdout.Write([]byte{0x0A}); e != nil {
+				errc <- errors.Wrap(e, "\nFailed to write the linefeed character on exit\n\n")
+			} else {
+				errc <- err
+			}
+			break
+		default:
+			if err != nil && !err.(net.Error).Timeout() {
+				errc <- errors.Wrap(err, "\nFailed to read the connection buffer from socket ")
+			}
+			// exit on ctrl + q
+			if bytes.Contains(b[0:n], []byte{0x11}) {
+				errc <- nil
+			}
+
+			if synchable, ok := param.Stdout.(*os.File); ok {
+				if err := synchable.Sync(); err != nil {
+					log.Warn("Failed %v to flush %s", param.Stdout, err)
+				}
+			}
+			_, err = param.Stdout.Write(b[0:n])
+			if err != nil {
+				errc <- errors.Wrap(err, "\nFailed to write to the console stdout buffer\n\n")
+			}
+		}
+	}
+}
+
+func (sc *SerialConnection) AttachSerialConsole(param *hypervisor.ConsoleParam, waitClosed *sync.WaitGroup, errc chan error) error {
+
+	go sc.stdinToConn(param, waitClosed, errc)
+	go sc.connToStdout(param, waitClosed, errc)
 
 	return nil
 }


### PR DESCRIPTION
Fixed some  problems with the serial console

* Executor failed due to nil pointer.
The goroutine reading the connection would sometimes be left running after the connection had already been closed resulting in the executor crashing.

* The return value sent returned by wait did not implement correct interface type.
The ssh service running on the executor expects the errors to be type asserted into `ConsoleWaitError` type.

* Exiting the console with return code, did not return a new line
