### PR TITLE
Add crashed node immediately

### DIFF
--- a/ci/citest/acceptance-test/tests/crash_recovery_test.go
+++ b/ci/citest/acceptance-test/tests/crash_recovery_test.go
@@ -20,9 +20,6 @@ func TestCrashRecovery(t *testing.T) {
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, "sudo systemctl stop mesos-slave", 10, 5)
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, "sudo lxc-stop -n "+instance_id+" -k", 10, 5)
 
-	t.Log("Waiting for scheduler to register crash...")
-	WaitConnectionStatus(t, 5*time.Minute, instance_id, "NOT_CONNECTED")
-
 	t.Log("Re-start mesos-slave...")
 	RunSshWithTimeoutAndReportFail(t, executor_lxc_ip, "sudo systemctl start mesos-slave", 10, 5)
 	WaitConnectionStatus(t, 5*time.Minute, instance_id, "CONNECTED")
@@ -33,6 +30,6 @@ func TestCrashRecovery(t *testing.T) {
 
 	_, _ = RunCmdWithTimeoutAndReportFail(t, 10, 5, "openvdc", "destroy", instance_id)
 
-	t.Log("Waiting for instance "+instance_id+" to become TERMINATED...")
+	t.Log("Waiting for instance " + instance_id + " to become TERMINATED...")
 	WaitInstance(t, 5*time.Minute, instance_id, "TERMINATED", nil)
 }

--- a/model/crashed_nodes.go
+++ b/model/crashed_nodes.go
@@ -24,6 +24,7 @@ type CrashedAgentNode interface {
 
 type CrashedNodesOps interface {
 	Add(node *CrashedNode) error
+	FindByAgentMesosIDNotReconnected(agentMesosID string) (*CrashedNode, error)
 	FindByAgentMesosID(agentMesosID string) (*CrashedNode, error)
 	FindByAgentID(agentID string) (*CrashedNode, error)
 	FindByUUID(nodeUUID string) (*CrashedNode, error)
@@ -91,6 +92,24 @@ func (i *crashedNodes) FindByAgentMesosID(agentMesosID string) (*CrashedNode, er
 	res := []*CrashedNode{}
 	err := i.Filter(1, func(node *CrashedNode) int {
 		if node.GetAgentMesosId() == agentMesosID {
+			res = append(res, node)
+		}
+		return len(res)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(res) > 0 {
+		return res[0], nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (i *crashedNodes) FindByAgentMesosIDNotReconnected(agentMesosID string) (*CrashedNode, error) {
+	res := []*CrashedNode{}
+	err := i.Filter(1, func(node *CrashedNode) int {
+		if node.GetAgentMesosId() == agentMesosID && node.GetReconnected() == false {
 			res = append(res, node)
 		}
 		return len(res)

--- a/pkg/conf/scripts/ovs-up.sh.tmpl
+++ b/pkg/conf/scripts/ovs-up.sh.tmpl
@@ -10,4 +10,9 @@ ACTION=$3  # up/down
 IFTYPE=$4  # veth,macvlan,etc...
 IFNAME=$5
 
+# When mesos-slave is stopped and restarted, all instances are momentarily stopped
+# without running the down.sh script causing defunct ports to remain on ovs.
+# Until a fix for that is found, we need to remove those on startup.
+ovs-vsctl del-port --if-exists {{.BridgeName}} "${IFNAME}"
+
 ovs-vsctl add-port {{.BridgeName}} "${IFNAME}"

--- a/pkg/conf/scripts/ovs-up.sh.tmpl
+++ b/pkg/conf/scripts/ovs-up.sh.tmpl
@@ -13,6 +13,6 @@ IFNAME=$5
 # When mesos-slave is stopped and restarted, all instances are momentarily stopped
 # without running the down.sh script causing defunct ports to remain on ovs.
 # Until a fix for that is found, we need to remove those on startup.
-ovs-vsctl del-port --if-exists {{.BridgeName}} "${IFNAME}"
+ovs-vsctl --if-exists del-port {{.BridgeName}} "${IFNAME}"
 
 ovs-vsctl add-port {{.BridgeName}} "${IFNAME}"

--- a/scheduler/mesos.go
+++ b/scheduler/mesos.go
@@ -503,6 +503,11 @@ func (sched *VDCScheduler) StatusUpdate(driver sched.SchedulerDriver, status *me
 		driver.ReviveOffers()
 	}
 
+	if status.GetState() == mesos.TaskState_TASK_LOST &&
+		status.GetReason() == mesos.TaskStatus_REASON_SLAVE_DISCONNECTED {
+		sched.SlaveLost(nil, status.GetSlaveId())
+	}
+
 	if status.GetState() == mesos.TaskState_TASK_LOST ||
 		status.GetState() == mesos.TaskState_TASK_ERROR ||
 		status.GetState() == mesos.TaskState_TASK_FAILED ||


### PR DESCRIPTION
It takes some time mesos to register a crash. Restarting mesos-slave before first waiting until a crash was registered causes the crash recovery feature to not kick in at all.

However, when mesos-slave is stopped, it does send `TASK_LOST` events with `SLAVE_DISCONNECTED` as the reason to openvdc-scheduler. I hooked into those events to add the crashed node immediately when mesos-slave goes down.

Of course it is still possible for mesos-slave to go down without sending the event if for example power is suddenly lost to the host. In that case the old behaviour of adding the crashed node after some time has passed still works.