### PR TITLE
Terraform: Force new instances when any of the network interfaces change

### DIFF
--- a/terraform/openvdc/resource_openvdc_instance.go
+++ b/terraform/openvdc/resource_openvdc_instance.go
@@ -33,21 +33,25 @@ func OpenVdcInstance() *schema.Resource {
 						"type": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							Default:  "veth",
 						},
 
 						"bridge": &schema.Schema{
 							Type:     schema.TypeString,
+							ForceNew: true,
 							Optional: true,
 						},
 
 						"ipv4addr": &schema.Schema{
 							Type:     schema.TypeString,
+							ForceNew: true,
 							Optional: true,
 						},
 
 						"macaddr": &schema.Schema{
 							Type:     schema.TypeString,
+							ForceNew: true,
 							Optional: true,
 						},
 					},


### PR DESCRIPTION
The other day I changed a mac address and noticed that the instance it was on didn't get recreated. Updated the terraform provider to always recreate an instance if a part of its network interfaces change.