### PR TITLE
Lxc console log

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,5 +126,6 @@ for( label in build_nodes) {
   stage_unit_test(label)
   stage_rpmbuild(label)
   stage_acceptance(label)
-  stage_acceptance_esxi(label)
+  // Esxi is currently unmaintained and needs to be removed from the code.
+  //stage_acceptance_esxi(label)
 }

--- a/hypervisor/lxc/lxc.go
+++ b/hypervisor/lxc/lxc.go
@@ -176,6 +176,9 @@ func (d *LXCHypervisorDriver) modifyConf() error {
 	}
 	defer lxcconf.Close()
 
+	// Log boot process to a file for debugging purposes
+	fmt.Fprintf(lxcconf, "\nlxc.console.logfile = %s\n\n", filepath.Join(d.containerDir(), "console.log"))
+
 	// Append comment header
 	fmt.Fprintf(lxcconf, "\n# OpenVDC Network Configuration\n")
 

--- a/hypervisor/lxc/lxc.go
+++ b/hypervisor/lxc/lxc.go
@@ -177,7 +177,7 @@ func (d *LXCHypervisorDriver) modifyConf() error {
 	defer lxcconf.Close()
 
 	// Log boot process to a file for debugging purposes
-	fmt.Fprintf(lxcconf, "\nlxc.console.logfile = %s\n\n", filepath.Join(d.containerDir(), "console.log"))
+	fmt.Fprintf(lxcconf, "\nlxc.console.logfile = %s\n", filepath.Join(d.containerDir(), "console.log"))
 
 	// Append comment header
 	fmt.Fprintf(lxcconf, "\n# OpenVDC Network Configuration\n")


### PR DESCRIPTION
Added a line to the lxc config file to keep its console log in a file.

For example instance `i-00000000` will save this file as `/var/lib/lxc/i-00000000/console.log`. When a container doesn't boot properly, this is very useful for debugging.