### PR TITLE
Disabled the esxi test stage in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,5 +126,6 @@ for( label in build_nodes) {
   stage_unit_test(label)
   stage_rpmbuild(label)
   stage_acceptance(label)
-  stage_acceptance_esxi(label)
+  // Esxi is currently unmaintained and needs to be removed from the code.
+  //stage_acceptance_esxi(label)
 }


### PR DESCRIPTION
I really don't like leaving unmaintained code in a project like this but since the ESXi server is stopped and there are no immediate plans to restore it, this change is necessary to continue development.

Without this change, the CI will wait forever for the ESXi server to become available.